### PR TITLE
도메인 엔티티 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,20 +23,20 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+//	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2' // local
-	runtimeOnly 'com.mysql:mysql-connector-j' // product
 	annotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+//	testImplementation 'org.springframework.security:spring-security-test'
+	testImplementation 'org.projectlombok:lombok:1.18.28'
 
 	// kargo, ide
-//	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client' // product
 
 	// third party
 	implementation group: 'com.auth0', name: 'java-jwt', version: '4.3.0'

--- a/src/main/java/com/theocean/fundering/FunderingApplication.java
+++ b/src/main/java/com/theocean/fundering/FunderingApplication.java
@@ -2,7 +2,9 @@ package com.theocean.fundering;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class FunderingApplication {
 

--- a/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
+++ b/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
@@ -1,5 +1,7 @@
 package com.theocean.fundering.domain.account.domain;
 
+import com.theocean.fundering.domain.post.domain.Post;
+import com.theocean.fundering.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -14,24 +16,19 @@ import java.util.Objects;
 @Entity
 public class Account {
     @Id
-    @Column(name = "account_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long accountId;
 
-    @Column(name = "user_id")
-    private Long userId;
+    @ManyToOne
+    private Member member;
 
-    @Column(name = "post_id")
-    private Long postId;
-
-    @Column(name = "funding_amount", nullable = false)
-    private Integer fundingAmount;
+    @ManyToOne
+    private Post post;
 
     @Builder
-    public Account(Integer fundingAmount) {
-        this.userId = userId;
-        this.postId = postId;
-        this.fundingAmount = fundingAmount;
+    public Account(Member member, Post post) {
+        this.member = member;
+        this.post = post;
     }
 
     @Override

--- a/src/main/java/com/theocean/fundering/domain/admin/domain/Admin.java
+++ b/src/main/java/com/theocean/fundering/domain/admin/domain/Admin.java
@@ -12,7 +12,7 @@ import jakarta.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "admin")
 @Entity
-public class Admin {
+public class Admin extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/theocean/fundering/domain/admin/domain/Admin.java
+++ b/src/main/java/com/theocean/fundering/domain/admin/domain/Admin.java
@@ -1,44 +1,40 @@
 package com.theocean.fundering.domain.admin.domain;
 
+import com.theocean.fundering.domain.account.domain.Account;
+import com.theocean.fundering.domain.global.AuditingFields;
 import com.theocean.fundering.domain.post.domain.Post;
-import com.theocean.fundering.domain.user.domain.User;
+import com.theocean.fundering.domain.member.domain.Member;
 import lombok.*;
 import jakarta.persistence.*;
 
-import com.theocean.fundering.account.domain.Account;
-
-@Entity
-@Table(name = "Admin")
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "admin")
+@Entity
 public class Admin {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "adminId")
     @EqualsAndHashCode.Include
-    private Long id;
+    private Long adminId;
 
     // 유저
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId")
-    private User user;
+    private Member member;
 
     // 게시물
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postId")
     private Post post;
 
     // 계좌
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "accountId")
     private Account account;
 
     // 생성자
     @Builder
-    public Admin(User user, Post post, Account account) {
-        this.user = user;
+    public Admin(Member member, Post post, Account account) {
+        this.member = member;
         this.post = post;
         this.account = account;
     }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
@@ -18,7 +18,7 @@ import java.util.Objects;
         indexes = @Index(columnList = "celebName")
 )
 @Entity
-public class Celebrity{
+public class Celebrity extends AuditingFields {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long celebId;

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
@@ -3,12 +3,11 @@ package com.theocean.fundering.domain.celebrity.domain;
 import com.theocean.fundering.celebrity.domain.constant.CelebGender;
 import com.theocean.fundering.celebrity.domain.constant.CelebType;
 import com.theocean.fundering.domain.follow.domain.Follow;
+import com.theocean.fundering.domain.global.AuditingFields;
+import com.theocean.fundering.domain.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -19,9 +18,8 @@ import java.util.Objects;
         indexes = @Index(columnList = "celebName")
 )
 @Entity
-public class Celebrity {
+public class Celebrity{
     @Id
-    @Column(name = "celebId")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long celebId;
 
@@ -44,27 +42,9 @@ public class Celebrity {
     @OneToMany(mappedBy = "celebrity")
     private List<Follow> followers;
 
-    /*
-        이후 fundering 객체로 리팩토링 예정
-    */
+    @OneToMany(mappedBy = "celebrity")
+    private List<Post> post;
 
-    @Column(nullable = false)
-    private Integer funderingCount;
-
-    @Column(nullable = false)
-    private Integer funderAmount;
-
-    /*
-        AuditingEntity로 리팩토링 예정
-    */
-
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;
 
     public void changeCelebName(String celebName) {
         this.celebName = celebName;

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -1,52 +1,35 @@
 package com.theocean.fundering.domain.comment.domain;
 
 
+import com.theocean.fundering.domain.global.AuditingFields;
+import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name="comment")
-public class Comment {
+public class Comment{
 
     @Id
-    @Column(name = "COMMENT_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
-
-    @Column(name = "USER_ID", nullable = false)
-    private Long userId;
-
-    @Column(name = "POST_ID", nullable = false)
-    private Long postId;
-
     @ManyToOne(fetch = FetchType.LAZY)
-    private User writer;
+    private Member writer;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Post post;
 
     @Column(nullable = false)
     private String content;
-
-    @Column(nullable = false)
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    @LastModifiedDate
-    private LocalDateTime modifiedAt;
 
     @Column(nullable = false)
     private boolean isDeleted;
@@ -64,7 +47,7 @@ public class Comment {
     private int replyCount;
 
     @Builder
-    public Comment(User writer, String content){
+    public Comment(Member writer, String content){
         this.writer = writer;
         this.content = content;
     }

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name="comment")
-public class Comment{
+public class Comment extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/theocean/fundering/domain/evidence/domain/Evidence.java
+++ b/src/main/java/com/theocean/fundering/domain/evidence/domain/Evidence.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "evidence")
 @Entity
-public class Evidence{
+public class Evidence extends AuditingFields {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long evidenceId;

--- a/src/main/java/com/theocean/fundering/domain/evidence/domain/Evidence.java
+++ b/src/main/java/com/theocean/fundering/domain/evidence/domain/Evidence.java
@@ -1,6 +1,9 @@
 package com.theocean.fundering.domain.evidence.domain;
 
 
+import com.theocean.fundering.domain.global.AuditingFields;
+import com.theocean.fundering.domain.member.domain.Member;
+import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.domain.withdrawal.domain.Withdrawal;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -13,30 +16,26 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "evidence")
-public class Evidence {
+@Entity
+public class Evidence{
     @Id
-    @Column(name = "evidence_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long evidenceId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "withdrawal_id")
     private Withdrawal withdrawal;
 
-    @Column(name = "user_id")
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
 
-    @Column(name = "post_id")
-    private Long postId;
-
-    @Column(name = "evidence_image")
-    private String evidenceImage;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
 
     @Builder
-    public Evidence(Long postId, Long userId, String evidenceImage) {
-        this.postId = postId;
-        this.userId = userId;
-        this.evidenceImage = evidenceImage;
+    public Evidence(Withdrawal withdrawal, Member member, Post post) {
+        this.withdrawal = withdrawal;
+        this.member = member;
+        this.post = post;
     }
 
     @Override

--- a/src/main/java/com/theocean/fundering/domain/follow/domain/Follow.java
+++ b/src/main/java/com/theocean/fundering/domain/follow/domain/Follow.java
@@ -2,7 +2,7 @@ package com.theocean.fundering.domain.follow.domain;
 
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
-import com.theocean.fundering.domain.user.domain.User;
+import com.theocean.fundering.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,10 +19,10 @@ import java.util.Objects;
 public class Follow {
     @Id
     @GeneratedValue
-    private Long id;
+    private Long followId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Celebrity celebrity;
@@ -31,11 +31,11 @@ public class Follow {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Follow follow)) return false;
-        return Objects.equals(id, follow.id);
+        return Objects.equals(followId, follow.followId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(followId);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/global/AuditingFields.java
+++ b/src/main/java/com/theocean/fundering/domain/global/AuditingFields.java
@@ -1,0 +1,29 @@
+package com.theocean.fundering.domain.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt; // 생성일시
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt; // 수정일시
+}

--- a/src/main/java/com/theocean/fundering/domain/like/domain/Heart.java
+++ b/src/main/java/com/theocean/fundering/domain/like/domain/Heart.java
@@ -2,40 +2,47 @@ package com.theocean.fundering.domain.like.domain;
 
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
-import com.theocean.fundering.domain.user.domain.User;
+import com.theocean.fundering.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.util.Objects;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name="heart")
 @Entity
-@EntityListeners(AuditingEntityListener.class)
-@Table(name="like")
-public class Like {
+public class Heart {
 
     @Id
-    @Column(name = "likeId")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long likeId;
+    private Long heartId;
 
-    @Column(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId")
-    private User user;
+    private Member member;
 
 
-    @Column(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "celebId")
     private Celebrity celeb;
 
 
     @Builder
-    public Like(User user, Celebrity celeb){
-        this.user = user;
+    public Heart(Member member, Celebrity celeb) {
+        this.member = member;
         this.celeb = celeb;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Heart heart)) return false;
+        return Objects.equals(heartId, heart.heartId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(heartId);
+    }
 }

--- a/src/main/java/com/theocean/fundering/domain/member/domain/Member.java
+++ b/src/main/java/com/theocean/fundering/domain/member/domain/Member.java
@@ -1,6 +1,7 @@
-package com.theocean.fundering.domain.user.domain;
+package com.theocean.fundering.domain.member.domain;
 
-import com.theocean.fundering.user.domain.constant.UserRole;
+import com.theocean.fundering.domain.global.AuditingFields;
+import com.theocean.fundering.domain.member.domain.constant.UserRole;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
@@ -13,11 +14,11 @@ import java.util.Objects;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user",
+@Table(name = "member",
     indexes = @Index(columnList = "email", unique = true)
 )
 @Entity
-public class User {
+public class Member{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;
@@ -35,18 +36,6 @@ public class User {
     @Enumerated(value = EnumType.STRING)
     private UserRole userRole;
 
-    /*
-        AuditingEntity로 리팩토링 예정
-    */
-
-    @CreatedDate
-    @Column(nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    @Column(nullable = false)
-    private LocalDateTime modifiedAt;
-
     public void changeNickname(String nickname){
         this.nickname = nickname;
     }
@@ -56,7 +45,7 @@ public class User {
     }
 
     @Builder
-    public User(String nickname, String password, String email, UserRole userRole) {
+    public Member(String nickname, String password, String email, UserRole userRole) {
         this.nickname = nickname;
         this.password = password;
         this.email = email;
@@ -66,8 +55,8 @@ public class User {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof User user)) return false;
-        return Objects.equals(userId, user.userId);
+        if (!(o instanceof Member member)) return false;
+        return Objects.equals(userId, member.userId);
     }
 
     @Override

--- a/src/main/java/com/theocean/fundering/domain/member/domain/Member.java
+++ b/src/main/java/com/theocean/fundering/domain/member/domain/Member.java
@@ -18,7 +18,7 @@ import java.util.Objects;
     indexes = @Index(columnList = "email", unique = true)
 )
 @Entity
-public class Member{
+public class Member extends AuditingFields {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long userId;

--- a/src/main/java/com/theocean/fundering/domain/member/domain/constant/UserRole.java
+++ b/src/main/java/com/theocean/fundering/domain/member/domain/constant/UserRole.java
@@ -1,4 +1,4 @@
-package com.theocean.fundering.domain.user.domain.constant;
+package com.theocean.fundering.domain.member.domain.constant;
 
 public enum UserRole {
     USER_ROLE,

--- a/src/main/java/com/theocean/fundering/domain/payment/domain/Payment.java
+++ b/src/main/java/com/theocean/fundering/domain/payment/domain/Payment.java
@@ -1,7 +1,8 @@
 package com.theocean.fundering.domain.payment.domain;
 
+import com.theocean.fundering.domain.global.AuditingFields;
 import com.theocean.fundering.domain.post.domain.Post;
-import com.theocean.fundering.domain.user.domain.User;
+import com.theocean.fundering.domain.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,39 +15,32 @@ import java.util.Objects;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-@Entity
-@Table(name = "Payment")
-@EntityListeners(AuditingEntityListener.class)
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "Payment")
+@Entity
 public class Payment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "paymentId")
-    private Long id;
+    private Long paymentId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId")
-    private User user;
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postId")
     private Post post;
 
     // 결제금액
-    @Column(name = "amount", nullable = false)
+    @Column(nullable = false)
     private Integer amount;
-
-    // 결제일시
-    @CreatedDate
-    @Column(name = "paymentDate")
-    private LocalDateTime paymentDate;
 
     // 생성자
     @Builder
-    public Payment(User user, Post post, Integer amount) {
-        this.user = user;
+    public Payment(Member member, Post post, Integer amount) {
+        this.member = member;
         this.post = post;
         this.amount = amount;
     }
@@ -54,14 +48,12 @@ public class Payment {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Payment payment = (Payment) o;
-        return Objects.equals(id, payment.id);
+        if (!(o instanceof Payment payment)) return false;
+        return Objects.equals(paymentId, payment.paymentId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(paymentId);
     }
-
 }

--- a/src/main/java/com/theocean/fundering/domain/payment/domain/Payment.java
+++ b/src/main/java/com/theocean/fundering/domain/payment/domain/Payment.java
@@ -21,7 +21,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "Payment")
 @Entity
-public class Payment {
+public class Payment extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/theocean/fundering/domain/post/domain/Post.java
+++ b/src/main/java/com/theocean/fundering/domain/post/domain/Post.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name="post")
-public class Post{
+public class Post extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/theocean/fundering/domain/post/domain/Post.java
+++ b/src/main/java/com/theocean/fundering/domain/post/domain/Post.java
@@ -2,8 +2,8 @@ package com.theocean.fundering.domain.post.domain;
 
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
-import com.theocean.fundering.domain.comment.domain.Comment;
-import com.theocean.fundering.domain.user.domain.User;
+import com.theocean.fundering.domain.global.AuditingFields;
+import com.theocean.fundering.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,23 +20,19 @@ import java.util.Objects;
 @Entity
 @EntityListeners(AuditingEntityListener.class)
 @Table(name="post")
-public class Post {
+public class Post{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postId;
 
 
-    @Column(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId")
-    private User writer;
+    private Member writer;
 
 
-    @Column(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "celebId")
-    private Celebrity celeb;
+    private Celebrity celebrity;
 
     @Column(nullable = false)
     private String title;
@@ -44,13 +40,6 @@ public class Post {
     @Column(nullable = false)
     private String content;
 
-    @Column(nullable = false)
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @Column(nullable = false)
-    @LastModifiedDate
-    private LocalDateTime modifiedAt;
 
     @Column
     private String thumbnail;
@@ -66,12 +55,12 @@ public class Post {
     private LocalDateTime deadline;
 
     @Column
-    private int order;
+    private int postOrder;
 
     @Builder
-    public Post(User writer, Celebrity celeb, String title, String content, String thumbnail){
+    public Post(Member writer, Celebrity celebrity, String title, String content, String thumbnail){
         this.writer = writer;
-        this.celeb = celeb;
+        this.celebrity = celebrity;
         this.title = title;
         this.content = content;
         this.thumbnail = thumbnail;

--- a/src/main/java/com/theocean/fundering/domain/update/domain/Update.java
+++ b/src/main/java/com/theocean/fundering/domain/update/domain/Update.java
@@ -1,7 +1,8 @@
 package com.theocean.fundering.domain.update.domain;
 
+import com.theocean.fundering.domain.global.AuditingFields;
 import com.theocean.fundering.domain.post.domain.Post;
-import com.theocean.fundering.domain.user.domain.User;
+import com.theocean.fundering.domain.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -15,10 +16,9 @@ import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "updates")
+@Table(name = "update")
 public class Update {
     @Id
-    @Column(name = "update_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long updateId;
 
@@ -26,24 +26,21 @@ public class Update {
     private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private User user;
+    private Member member;
 
-    @Column(name = "title", nullable = false)
+    @Column(nullable = false)
     private String title;
 
-    @Column(name = "content", nullable = false)
+    @Column(nullable = false)
     private String content;
 
-    @CreatedDate
-    @Column(nullable = false)
-    private LocalDateTime createdAt;
 
-    @Column(name = "update_order")
+    @Column(nullable = false)
     private Integer updateOrder;
 
-    public Update(Post post, User user, String title, String content) {
+    public Update(Post post, Member member, String title, String content) {
         this.post = post;
-        this.user = user;
+        this.member = member;
         this.title = title;
         this.content = content;
     }

--- a/src/main/java/com/theocean/fundering/domain/update/domain/Update.java
+++ b/src/main/java/com/theocean/fundering/domain/update/domain/Update.java
@@ -17,7 +17,7 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "update")
-public class Update {
+public class Update extends AuditingFields {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long updateId;

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
@@ -1,7 +1,8 @@
 package com.theocean.fundering.domain.withdrawal.domain;
 
+import com.theocean.fundering.domain.global.AuditingFields;
 import com.theocean.fundering.domain.post.domain.Post;
-import com.theocean.fundering.domain.user.domain.User;
+import com.theocean.fundering.domain.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ import java.util.Objects;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @Entity
 @Table(name = "Withdrawal")
@@ -23,47 +25,41 @@ public class Withdrawal {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "withdrawalId")
-    private Long id;
+    private Long withdrawal_id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "userId")
-    private User user;
+    private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "postId")
     private Post post;
 
     // 사용처
-    @Column(name = "usage", nullable = false)
+    @Column(nullable = false)
     private String usage;
 
     // 출금계좌
-    @Column(name = "depositAccount", nullable = false)
+    @Column(nullable = false)
     private String depositAccount;
 
     // 출금액
-    @Column(name = "withdrawalAmount", nullable = false)
+    @Column(nullable = false)
     private Integer withdrawalAmount;
 
     // 신청일자
     @CreatedDate
-    @Column(name = "createdAt", nullable = false)
+    @Column(nullable = false)
     private LocalDateTime createdAt;
 
     // 승인 여부
-    @Column(name = "isApproved", nullable = false)
+    @Column(nullable = false)
     private Boolean isApproved;
 
-    // 승인 일자
-    @Column(name = "approvalDate")
-    private LocalDateTime approvalDate;
 
     // 생성자
     @Builder
-    public Withdrawal(User user, Post post, String usage, String depositAccount,
+    public Withdrawal(Member member, Post post, String usage, String depositAccount,
                       Integer withdrawalAmount, Boolean isApproved) {
-        this.user = user;
+        this.member = member;
         this.post = post;
         this.usage = usage;
         this.depositAccount = depositAccount;
@@ -88,20 +84,15 @@ public class Withdrawal {
         this.isApproved = isApproved;
     }
 
-    public void updateApprovalDate(LocalDateTime approvalDate) {
-        this.approvalDate = approvalDate;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Withdrawal that = (Withdrawal) o;
-        return Objects.equals(id, that.id);
+        if (!(o instanceof Withdrawal that)) return false;
+        return Objects.equals(withdrawal_id, that.withdrawal_id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(withdrawal_id);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
@@ -21,7 +21,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Withdrawal {
+public class Withdrawal extends AuditingFields {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,8 @@ server:
   port: 8080
 spring:
   datasource:
-    url: jdbc:h2:tcp://localhost/~/fundering;MODE=MySQL
+#    url: jdbc:h2:tcp://localhost/~/fundering;MODE=MySQL
+    url: jdbc:h2:mem:test;MODE=MySQL
     username: sa
     password:
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
## 주요 사항
- 데이터베이스 예약어와 중복되는 엔티티 이름, 컬럼 이름 변경
- 데이터베이스 컬럼 이름 통일
- createAt, modifiedAt 공통 필드, AuditingFields로 리팩토링
- 스프링 시큐리티 설정 및 데이터베이스 설정 변경

### 관련 이슈
#16 
