### PR TITLE
댓글 기능 리팩토링

### DIFF
--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.theocean.fundering.domain.comment.controller;
 
 import com.theocean.fundering.domain.comment.dto.CommentRequest;
+import com.theocean.fundering.domain.comment.dto.CommentResponse;
 import com.theocean.fundering.domain.comment.service.CommentService;
 import com.theocean.fundering.domain.comment.domain.Comment;
 import com.theocean.fundering.global.utils.ApiUtils;
@@ -32,7 +33,7 @@ public class CommentController {
                                          @RequestParam(required = false, defaultValue = "0") int pageIndex,
                                          @RequestParam(required = false, defaultValue = "3") int pageSize) {
 
-        Map<String, Object> response = commentService.getCommentsDtoByPostId(postId, PageRequest.of(pageIndex, pageSize));
+        CommentResponse.findAllDTO response = commentService.getCommentsDtoByPostId(postId, PageRequest.of(pageIndex, pageSize));
         return ResponseEntity.ok(ApiUtils.success(response));
     }
 

--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -23,7 +23,7 @@ public class CommentController {
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<?> createComment(@RequestBody @Valid CommentRequest.saveDTO commentRequest, @PathVariable long postId) {
         // TODO: memberId 부분은 authentication를 통해 작성자 확인 필요
-        Comment comment = commentService.createComment(1L, postId, commentRequest);
+        commentService.createComment(1L, postId, commentRequest);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 
@@ -41,7 +41,8 @@ public class CommentController {
     @DeleteMapping("/posts/{postId}/comments/{commentId}")
     public ResponseEntity<?> deleteComment(@PathVariable long postId, @PathVariable long commentId) {
         // TODO: authentication를 통해 작성자 확인 필요
-        commentService.deleteComment(commentId);
+        Long memberId = 1L;  // 임시 코드, 실제로는 인증 정보에서 가져와야 함
+        commentService.deleteComment(memberId, postId, commentId);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -2,8 +2,6 @@ package com.theocean.fundering.domain.comment.domain;
 
 
 import com.theocean.fundering.global.utils.AuditingFields;
-import com.theocean.fundering.domain.member.domain.Member;
-import com.theocean.fundering.domain.post.domain.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -29,13 +27,13 @@ public class Comment extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
-    // 작성자
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member writer;
+    // 작성자의 식별자
+    @Column(nullable = false)
+    private Long writerId;
 
-    // 게시물
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Post post;
+    // 게시물의 식별자
+    @Column(nullable = false)
+    private Long postId;
 
     // 댓글 내용
     @Column(nullable = false)
@@ -45,9 +43,9 @@ public class Comment extends AuditingFields {
     @Column(nullable = false)
     private boolean isDeleted;
 
-    // 대댓글 여부 - true이면 부모댓글 즉, 대댓글이 없는 것이다.
+    // 대댓글 유무 - true이면 답글이 존재하므로 대댓글임을 의미함
     @Column(nullable = false)
-    private boolean isParentComment;
+    private boolean hasReply;
 
     /*
         commentOrder는 댓글이 생성될 때 부여받는 순서이다.
@@ -65,20 +63,20 @@ public class Comment extends AuditingFields {
     private int childCommentCount;
 
     @Builder
-    public Comment(Member writer, Post post, String content, Long commentOrder) {
-        this.writer = writer;
-        this.post = post;
+    public Comment(Long writerId, Long postId, String content, Long commentOrder) {
+        this.writerId = writerId;
+        this.postId = postId;
         this.content = content;
         this.commentOrder = commentOrder;
-        this.isParentComment = true;
+        this.hasReply = false;
         this.parentCommentOrder = null;
         this.childCommentCount = 0;
         this.isDeleted = false;
     }
 
 
-    public void updateIsParentComment(Boolean isParentComment) {
-        this.isParentComment = isParentComment;
+    public void updatehasReply(Boolean hasReply) {
+        this.hasReply = hasReply;
     }
 
     public void updateParentCommentOrder(Long parentCommentOrder) {

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 @EntityListeners(AuditingEntityListener.class)
 @Table(name="comment")
 @SQLDelete(sql = "UPDATE comment SET is_deleted = true WHERE comment_id = ?")
-@Where(clause = "is_deleted = false")
 public class Comment extends AuditingFields {
 
     // PK

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -89,6 +89,7 @@ public class Comment extends AuditingFields {
         this.childCommentCount++;
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
@@ -3,28 +3,46 @@ package com.theocean.fundering.domain.comment.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.theocean.fundering.domain.comment.domain.Comment;
 import lombok.Data;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 
 public class CommentResponse {
 
-    @Data
+    @Getter
     public static class findAllDTO {
-        private Long commentId;
-        private Long writerId;
-        private String writerName;
-        private String writerProfile;
-        private String content;
-        private Long parentCommentOrder;
-        private Long commentOrder;
-        private int childCommentCount;
+        private final List<commentsDTO> comments;
+
+        @JsonProperty("isLastPage")
+        private final boolean isLastPage;
+
+        public findAllDTO(List<commentsDTO> comments, boolean isLastPage) {
+            this.comments = comments;
+            this.isLastPage = isLastPage;
+        }
+
+        public boolean getIsLastPage() {
+            return isLastPage;
+        }
+    }
+    @Getter
+    public static class commentsDTO {
+        private final Long commentId;
+        private final Long writerId;
+        private final String writerName;
+        private final String writerProfile;
+        private final String content;
+        private final Long parentCommentOrder;
+        private final Long commentOrder;
+        private final int childCommentCount;
 
         @JsonProperty("isDeleted")
-        private boolean isDeleted;
-        private LocalDateTime createdAt;
+        private final boolean isDeleted;
+        private final LocalDateTime createdAt;
 
-        public findAllDTO(Comment comment) {
+        public commentsDTO(Comment comment) {
             this.commentId = comment.getCommentId();
             this.writerId = comment.getWriter().getUserId();
             this.writerName = comment.getWriter().getNickname();

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
@@ -36,7 +36,7 @@ public class CommentResponse {
         private final String content;
         private final Long parentCommentOrder;
         private final Long commentOrder;
-        private final int childCommentCount;
+
 
         @JsonProperty("isDeleted")
         private final boolean isDeleted;
@@ -51,9 +51,12 @@ public class CommentResponse {
             this.content = comment.getContent();
             this.parentCommentOrder = comment.getParentCommentOrder();
             this.commentOrder = comment.getCommentOrder();
-            this.childCommentCount = comment.getChildCommentCount();
             this.isDeleted = comment.isDeleted();
             this.createdAt = comment.getCreatedAt();
+        }
+
+        public boolean getIsDeleted() {
+            return isDeleted;
         }
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
@@ -2,7 +2,6 @@ package com.theocean.fundering.domain.comment.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.theocean.fundering.domain.comment.domain.Comment;
-import lombok.Data;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
@@ -42,12 +41,11 @@ public class CommentResponse {
         private final boolean isDeleted;
         private final LocalDateTime createdAt;
 
-        public commentsDTO(Comment comment) {
+        public commentsDTO(Comment comment, String writerName, String writerProfile) {
             this.commentId = comment.getCommentId();
-            this.writerId = comment.getWriter().getUserId();
-            this.writerName = comment.getWriter().getNickname();
-            this.writerProfile = "ImageURL_Example";
-//            this.writerProfile = comment.getWriter().getProfileImage();
+            this.writerId = comment.getWriterId();
+            this.writerName = writerName;
+            this.writerProfile = writerProfile;
             this.content = comment.getContent();
             this.parentCommentOrder = comment.getParentCommentOrder();
             this.commentOrder = comment.getCommentOrder();

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
@@ -1,6 +1,7 @@
 package com.theocean.fundering.domain.comment.repository;
 
 import com.theocean.fundering.domain.comment.domain.Comment;
+import com.theocean.fundering.domain.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,7 +16,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT COALESCE(MAX(c.commentOrder), 0) FROM Comment c WHERE c.post.postId = :postId")
     Long getLastCommentOrder(@Param("postId") Long postId);
 
-    Optional<Comment> findByCommentOrder(Long parentCommentOrder);
+    Optional<Comment> findByPostAndCommentOrder(Post post, Long commentOrder);
 
     Page<Comment> findByPost_PostIdOrderByParentCommentOrderAscCommentOrderAsc(Long postId, Pageable pageable);
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,6 @@
 package com.theocean.fundering.domain.comment.repository;
 
 import com.theocean.fundering.domain.comment.domain.Comment;
-import com.theocean.fundering.domain.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,10 +12,12 @@ import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    @Query("SELECT COALESCE(MAX(c.commentOrder), 0) FROM Comment c WHERE c.post.postId = :postId")
+    @Query("SELECT COALESCE(MAX(c.commentOrder), 0) FROM Comment c WHERE c.postId = :postId")
     Long getLastCommentOrder(@Param("postId") Long postId);
 
-    Optional<Comment> findByPostAndCommentOrder(Post post, Long commentOrder);
+    Optional<Comment> findByPostIdAndCommentOrder(Long postId, Long commentOrder);
 
-    Page<Comment> findByPost_PostIdOrderByParentCommentOrderAscCommentOrderAsc(Long postId, Pageable pageable);
+    @Query("SELECT c FROM Comment c WHERE c.postId = :postId ORDER BY c.parentCommentOrder, c.commentOrder")
+    Page<Comment> findByPostIdOrdered(Long postId, Pageable pageable);
+
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
@@ -20,4 +20,7 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("SELECT c FROM Comment c WHERE c.postId = :postId ORDER BY c.parentCommentOrder, c.commentOrder")
     Page<Comment> findByPostIdOrdered(Long postId, Pageable pageable);
 
+    boolean existsByPostIdAndCommentOrder(Long postId, Long commentOrder);
+
+
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/service/CommentService.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/service/CommentService.java
@@ -55,7 +55,7 @@ public class CommentService {
 
         // 대댓글 생성 로직 (부모 댓글이 존재할 경우)
         if (parentCommentOrder != null) {
-            Comment parentComment = commentRepository.findByCommentOrder(parentCommentOrder)
+            Comment parentComment = commentRepository.findByPostAndCommentOrder(post, parentCommentOrder)
                     .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다: " + parentCommentOrder));
 
             newComment.updateParentCommentOrder(parentCommentOrder);

--- a/src/main/java/com/theocean/fundering/domain/comment/service/CommentService.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/service/CommentService.java
@@ -75,22 +75,17 @@ public class CommentService {
 
 
     // (기능) 댓글 목록 조회
-    public Map<String, Object> getCommentsDtoByPostId(long postId, PageRequest pageRequest) {
+    public CommentResponse.findAllDTO getCommentsDtoByPostId(long postId, PageRequest pageRequest) {
         Page<Comment> commentsPage = commentRepository.findByPost_PostIdOrderByParentCommentOrderAscCommentOrderAsc(postId, pageRequest);
 
-        // Comment 객체들을 CommentResponse.findAllDTO 객체들로 변환
-        List<CommentResponse.findAllDTO> responseDtos = commentsPage.getContent().stream()
-                .map(CommentResponse.findAllDTO::new)
+        // Comment 객체들을 CommentResponse.commentsDTO 객체들로 변환
+        List<CommentResponse.commentsDTO> commentsDtos = commentsPage.getContent().stream()
+                .map(CommentResponse.commentsDTO::new)
                 .collect(Collectors.toList());
 
-
-        boolean isLastPage = commentsPage.isLast();
-        Map<String, Object> response = new HashMap<>();
-        response.put("comments", responseDtos);
-        response.put("isLastPage", isLastPage);
-
-        return response;
+        return new CommentResponse.findAllDTO(commentsDtos, commentsPage.isLast());
     }
+
 
     // (기능) 댓글 삭제
     @Transactional

--- a/src/main/java/com/theocean/fundering/global/errors/GlobalExceptionHandler.java
+++ b/src/main/java/com/theocean/fundering/global/errors/GlobalExceptionHandler.java
@@ -1,0 +1,64 @@
+package com.theocean.fundering.global.errors;
+
+import com.theocean.fundering.global.errors.exception.*;
+import com.theocean.fundering.global.utils.ApiUtils;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.util.List;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception400.class)
+    public ResponseEntity<?> badRequest(Exception400 e){
+        return new ResponseEntity<>(e.body(), e.status());
+    }
+
+    @ExceptionHandler(Exception401.class)
+    public ResponseEntity<?> unAuthorized(Exception401 e){
+        return new ResponseEntity<>(e.body(), e.status());
+    }
+
+    @ExceptionHandler(Exception403.class)
+    public ResponseEntity<?> forbidden(Exception403 e){
+        return new ResponseEntity<>(e.body(), e.status());
+    }
+
+    @ExceptionHandler(Exception404.class)
+    public ResponseEntity<?> notFound(Exception404 e){
+        return new ResponseEntity<>(e.body(), e.status());
+    }
+
+    @ExceptionHandler(Exception500.class)
+    public ResponseEntity<?> serverError(Exception500 e){
+        return new ResponseEntity<>(e.body(), e.status());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        BindingResult bindingResult = ex.getBindingResult();
+        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+
+        // 필드 에러들 중에서 첫 번째 에러의 기본 메시지만 가져옵니다.
+        String errorMessage = fieldErrors.stream()
+                .findFirst()
+                .map(FieldError::getDefaultMessage)
+                .orElse("Validation error");
+
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.error(errorMessage, HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(apiResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<?> unknownServerError(Exception e){
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+}

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception400.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception400.java
@@ -1,0 +1,23 @@
+package com.theocean.fundering.global.errors.exception;
+
+
+import com.theocean.fundering.global.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 유효성 검사 실패, 잘못된 파라메터 요청
+@Getter
+public class Exception400 extends RuntimeException {
+
+    public Exception400(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception401.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception401.java
@@ -1,0 +1,20 @@
+package com.theocean.fundering.global.errors.exception;
+
+import com.theocean.fundering.global.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception401 extends RuntimeException {
+    public Exception401(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.UNAUTHORIZED;
+    }
+}

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception403.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception403.java
@@ -1,0 +1,20 @@
+package com.theocean.fundering.global.errors.exception;
+
+import com.theocean.fundering.global.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class Exception403 extends RuntimeException {
+    public Exception403(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.FORBIDDEN);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.FORBIDDEN;
+    }
+}

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception404.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception404.java
@@ -1,0 +1,21 @@
+package com.theocean.fundering.global.errors.exception;
+
+import com.theocean.fundering.global.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 권한 없음
+@Getter
+public class Exception404 extends RuntimeException {
+    public Exception404(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception500.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception500.java
@@ -1,0 +1,21 @@
+package com.theocean.fundering.global.errors.exception;
+
+import com.theocean.fundering.global.utils.ApiUtils;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+// 서버 에러
+@Getter
+public class Exception500 extends RuntimeException {
+    public Exception500(String message) {
+        super(message);
+    }
+
+    public ApiUtils.ApiResult<?> body(){
+        return ApiUtils.error(getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    public HttpStatus status(){
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/src/main/java/com/theocean/fundering/global/utils/ApiUtils.java
+++ b/src/main/java/com/theocean/fundering/global/utils/ApiUtils.java
@@ -1,0 +1,30 @@
+package com.theocean.fundering.global.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.http.HttpStatus;
+
+public class ApiUtils {
+
+    public static <T> ApiResult<T> success(T response) {
+        return new ApiResult<>(true, response, null);
+    }
+
+    public static ApiResult<?> error(String message, HttpStatus status) {
+        return new ApiResult<>(false, null, new ApiError(message, status.value()));
+    }
+
+    @Getter @Setter @AllArgsConstructor
+    public static class ApiResult<T> {
+        private final boolean success;
+        private final T response;
+        private final ApiError error;
+    }
+
+    @Getter @Setter @AllArgsConstructor
+    public static class ApiError {
+        private final String message;
+        private final int status;
+    }
+}

--- a/src/main/java/com/theocean/fundering/global/utils/AuditingFields.java
+++ b/src/main/java/com/theocean/fundering/global/utils/AuditingFields.java
@@ -1,4 +1,4 @@
-package com.theocean.fundering.domain.global;
+package com.theocean.fundering.global.utils;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;


### PR DESCRIPTION
## 주요 사항
- JPA soft delete
- 서비스 리턴 객체 DTO 직접 반환하도록 로직 수정, 서비스 리턴 필드값 final로 변경
- Comment의 Post와 Member에 대한 의존성 감소
- 예외 처리

## 스크린샷

![sequenceDiagram](https://github.com/Step3-kakao-tech-campus/Team13_BE/assets/79629515/2d81e3f0-8207-4b76-b675-e4e0137eb70c)

## 궁금한 점

향후 리팩토링 계획

1. 쿼리 DSL
2. no offset 페이지네이션 적용
3. commentOrder 동시성 문제 해결

댓글 순서를 정함에 있어서 동시성 문제가 발생할 수 있습니다. 현재 commentOrder 필드에 대한 잠금을 하여 다른 트랜잭션의 접근을 막는 방식으로 해결할 예정인데, 더 효율적인 방법이 있을 지 궁금합니다!

### 관련 이슈
#25 
