### PR TITLE
댓글 피드백 사항 반영

### DIFF
--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -8,6 +8,7 @@ import com.theocean.fundering.global.utils.ApiUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,6 +19,7 @@ public class CommentController {
     private final CommentService commentService;
 
     // (기능) 댓글 작성
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<?> createComment(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody @Valid CommentRequest.saveDTO commentRequest, @PathVariable long postId) {
 
@@ -41,6 +43,7 @@ public class CommentController {
 
 
     // (기능) 댓글 삭제
+    @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/posts/{postId}/comments/{commentId}")
     public ResponseEntity<?> deleteComment(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable long postId, @PathVariable long commentId) {
 

--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -3,15 +3,13 @@ package com.theocean.fundering.domain.comment.controller;
 import com.theocean.fundering.domain.comment.dto.CommentRequest;
 import com.theocean.fundering.domain.comment.dto.CommentResponse;
 import com.theocean.fundering.domain.comment.service.CommentService;
-import com.theocean.fundering.domain.comment.domain.Comment;
+import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
 import com.theocean.fundering.global.utils.ApiUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,28 +19,32 @@ public class CommentController {
 
     // (기능) 댓글 작성
     @PostMapping("/posts/{postId}/comments")
-    public ResponseEntity<?> createComment(@RequestBody @Valid CommentRequest.saveDTO commentRequest, @PathVariable long postId) {
-        // TODO: memberId 부분은 authentication를 통해 작성자 확인 필요
-        commentService.createComment(1L, postId, commentRequest);
+    public ResponseEntity<?> createComment(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody @Valid CommentRequest.saveDTO commentRequest, @PathVariable long postId) {
+
+        Long memberId = 1L;  // Long memberId = userDetails.getMember().getUserId();
+        commentService.createComment(memberId, postId, commentRequest);
+
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 
     // (기능) 댓글 목록 조회
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<?> getComments(@PathVariable long postId,
-                                         @RequestParam(required = false, defaultValue = "0") int pageIndex,
-                                         @RequestParam(required = false, defaultValue = "3") int pageSize) {
+                                         @RequestParam(required = false, defaultValue = "0") Long lastCommentId,
+                                         @RequestParam(required = false, defaultValue = "5") int pageSize) {
 
-        CommentResponse.findAllDTO response = commentService.getCommentsDtoByPostId(postId, PageRequest.of(pageIndex, pageSize));
+        CommentResponse.findAllDTO response = commentService.getCommentsDtoByPostId(postId, lastCommentId, pageSize);
+
         return ResponseEntity.ok(ApiUtils.success(response));
     }
 
     // (기능) 댓글 삭제
     @DeleteMapping("/posts/{postId}/comments/{commentId}")
-    public ResponseEntity<?> deleteComment(@PathVariable long postId, @PathVariable long commentId) {
-        // TODO: authentication를 통해 작성자 확인 필요
-        Long memberId = 1L;  // 임시 코드, 실제로는 인증 정보에서 가져와야 함
+    public ResponseEntity<?> deleteComment(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable long postId, @PathVariable long commentId) {
+
+        Long memberId = userDetails.getMember().getUserId();
         commentService.deleteComment(memberId, postId, commentId);
+
         return ResponseEntity.ok(ApiUtils.success(null));
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -33,7 +33,7 @@ public class CommentController {
                                          @RequestParam(required = false, defaultValue = "0") Long lastCommentId,
                                          @RequestParam(required = false, defaultValue = "5") int pageSize) {
 
-        CommentResponse.findAllDTO response = commentService.getCommentsDtoByPostId(postId, lastCommentId, pageSize);
+        CommentResponse.findAllDTO response = commentService.getComments(postId, lastCommentId, pageSize);
 
         return ResponseEntity.ok(ApiUtils.success(response));
     }

--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -32,11 +32,11 @@ public class CommentController {
     // (기능) 댓글 목록 조회
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<?> getComments(@PathVariable long postId,
-                                         @RequestParam(required = false, defaultValue = "0") int lastGroup,
+                                         @RequestParam(required = false, defaultValue = "0") int lastRef,
                                          @RequestParam(required = false, defaultValue = "0") int lastOrder,
                                          @RequestParam(required = false, defaultValue = "5") int pageSize) {
 
-        CommentResponse.findAllDTO response = commentService.getComments(postId, lastGroup, lastOrder, pageSize);
+        CommentResponse.findAllDTO response = commentService.getComments(postId, lastRef, lastOrder, pageSize);
 
         return ResponseEntity.ok(ApiUtils.success(response));
     }

--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -30,13 +30,15 @@ public class CommentController {
     // (기능) 댓글 목록 조회
     @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<?> getComments(@PathVariable long postId,
-                                         @RequestParam(required = false, defaultValue = "0") Long lastCommentId,
+                                         @RequestParam(required = false, defaultValue = "0") int lastGroup,
+                                         @RequestParam(required = false, defaultValue = "0") int lastOrder,
                                          @RequestParam(required = false, defaultValue = "5") int pageSize) {
 
-        CommentResponse.findAllDTO response = commentService.getComments(postId, lastCommentId, pageSize);
+        CommentResponse.findAllDTO response = commentService.getComments(postId, lastGroup, lastOrder, pageSize);
 
         return ResponseEntity.ok(ApiUtils.success(response));
     }
+
 
     // (기능) 댓글 삭제
     @DeleteMapping("/posts/{postId}/comments/{commentId}")

--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -47,7 +47,7 @@ public class CommentController {
     @DeleteMapping("/posts/{postId}/comments/{commentId}")
     public ResponseEntity<?> deleteComment(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable long postId, @PathVariable long commentId) {
 
-        Long memberId = userDetails.getMember().getUserId();
+        Long memberId = 1L;  // userDetails.getMember().getUserId();
         commentService.deleteComment(memberId, postId, commentId);
 
         return ResponseEntity.ok(ApiUtils.success(null));

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -41,35 +41,29 @@ public class Comment extends AuditingFields {
     @Column(nullable = false)
     private boolean isDeleted;
 
-    // true이면 대댓글 -> 대댓글을 작성할 수 없음.
-    @Column(nullable = false)
-    private boolean isReply;
+    @Column(name = "`GROUP`", nullable = false)
+    private int group;  // 댓글 조회시 분류를 위한 그룹핑 - 대댓글은 원댓글의 필드값을 따라가고, 원댓글의 경우 자신의 PK값을 갖는다
 
-    // 부모 댓글의 ID
-    @Column
-    private Long parentCommentId;
+    @Column(name = "`ORDER`", nullable = false)
+    private int order;  // 같은 그룹내에서 댓글 순서 - 생성순, 원댓글은 0
+
+    @Column(nullable = false)
+    private int depth;  // 화면에 표시되는 들여쓰기 수준 - 원댓글 0부터 시작
 
     @Builder
-    public Comment(Long writerId, Long postId, String content, boolean isReply, Long parentCommentId) {
+    public Comment(Long writerId, Long postId, String content) {
         this.writerId = writerId;
         this.postId = postId;
         this.content = content;
-        this.isReply = isReply;
-        this.parentCommentId = parentCommentId;
         this.isDeleted = false;
     }
 
-    public void updateIsReply(Boolean isReply) {
-        this.isReply = isReply;
+    public void updateCommentProperties(int group, int order, int depth) {
+        this.group = group;
+        this.order = order;
+        this.depth = depth;
     }
 
-    public boolean getIsReply() {
-        return isReply;
-    }
-
-    public boolean getIsDeleted() {
-        return isDeleted;
-    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -41,7 +41,7 @@ public class Comment extends AuditingFields {
     @Column(nullable = false)
     private boolean isDeleted;
 
-    // false이면 대댓글 -> 대댓글을 작성할 수 없음.
+    // true이면 대댓글 -> 대댓글을 작성할 수 없음.
     @Column(nullable = false)
     private boolean isReply;
 
@@ -57,6 +57,10 @@ public class Comment extends AuditingFields {
         this.isReply = isReply;
         this.parentCommentId = parentCommentId;
         this.isDeleted = false;
+    }
+
+    public void updateIsReply(Boolean isReply) {
+        this.isReply = isReply;
     }
 
     @Override

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -41,11 +41,11 @@ public class Comment extends AuditingFields {
     @Column(nullable = false)
     private boolean isDeleted;
 
-    @Column(name = "`GROUP`", nullable = false)
-    private int group;  // 댓글 조회시 분류를 위한 그룹핑 - 대댓글은 원댓글의 필드값을 따라가고, 원댓글의 경우 자신의 PK값을 갖는다
+    @Column(nullable = false)
+    private int ref;  // 댓글 조회시 분류를 위한 그룹핑 - 대댓글은 원댓글의 필드값을 따라가고, 원댓글의 경우 자신의 PK값을 갖는다
 
-    @Column(name = "`ORDER`", nullable = false)
-    private int order;  // 같은 그룹내에서 댓글 순서 - 생성순, 원댓글은 0
+    @Column(nullable = false)
+    private int refOrder;  // 같은 그룹내에서 댓글 순서 - 생성순, 원댓글은 0
 
     @Column(nullable = false)
     private int depth;  // 화면에 표시되는 들여쓰기 수준 - 원댓글 0부터 시작
@@ -58,9 +58,9 @@ public class Comment extends AuditingFields {
         this.isDeleted = false;
     }
 
-    public void updateCommentProperties(int group, int order, int depth) {
-        this.group = group;
-        this.order = order;
+    public void updateCommentProperties(int ref, int refOrder, int depth) {
+        this.ref = ref;
+        this.refOrder = refOrder;
         this.depth = depth;
     }
 

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -63,6 +63,14 @@ public class Comment extends AuditingFields {
         this.isReply = isReply;
     }
 
+    public boolean getIsReply() {
+        return isReply;
+    }
+
+    public boolean getIsDeleted() {
+        return isDeleted;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -11,6 +11,12 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.Objects;
 
+/*
+ 로그인한 사용자는 댓글 작성 부분에 입력을 하여 댓글을 작성할 수 있다.
+ 또한 댓글 옆에 댓글 작성 버튼을 클릭하여 대댓글을 작성할 수 있다.
+ 대댓글에 대한 대댓글은 허용되지 않는다.
+*/
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
@@ -35,6 +41,7 @@ public class Comment extends AuditingFields {
     @Column(nullable = false)
     private boolean isDeleted;
 
+    // false이면 대댓글 -> 대댓글을 작성할 수 없음.
     @Column(nullable = false)
     private boolean isReply;
 

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -1,6 +1,5 @@
 package com.theocean.fundering.domain.comment.domain;
 
-
 import com.theocean.fundering.global.utils.AuditingFields;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.Objects;
@@ -17,75 +15,42 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(name="comment")
+@Table(name = "comment")
 @SQLDelete(sql = "UPDATE comment SET is_deleted = true WHERE comment_id = ?")
 public class Comment extends AuditingFields {
 
-    // PK
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long commentId;
 
-    // 작성자의 식별자
     @Column(nullable = false)
     private Long writerId;
 
-    // 게시물의 식별자
     @Column(nullable = false)
     private Long postId;
 
-    // 댓글 내용
     @Column(nullable = false)
     private String content;
 
-    // 삭제 여부
     @Column(nullable = false)
     private boolean isDeleted;
 
-    // 대댓글 유무 - true이면 답글이 존재하므로 대댓글임을 의미함
     @Column(nullable = false)
-    private boolean hasReply;
+    private boolean isReply;
 
-    /*
-        commentOrder는 댓글이 생성될 때 부여받는 순서이다.
-        Comment에서는 부모댓글의 PK를 필드값으로 갖는 대신에 부모 댓글 순서를 필드값으로 가지고 있는다.
-        만약 부모댓글이 없을 경우 자기자신의 commentOrder를 parentCommentOrder필드값으로 갖는다.
-    */
+    // 부모 댓글의 ID
     @Column
-    private Long parentCommentOrder;
-
-    @Column(nullable = false)
-    private Long commentOrder;
-
-    // 대댓글 수
-    @Column(nullable = false)
-    private int childCommentCount;
+    private Long parentCommentId;
 
     @Builder
-    public Comment(Long writerId, Long postId, String content, Long commentOrder) {
+    public Comment(Long writerId, Long postId, String content, boolean isReply, Long parentCommentId) {
         this.writerId = writerId;
         this.postId = postId;
         this.content = content;
-        this.commentOrder = commentOrder;
-        this.hasReply = false;
-        this.parentCommentOrder = null;
-        this.childCommentCount = 0;
+        this.isReply = isReply;
+        this.parentCommentId = parentCommentId;
         this.isDeleted = false;
     }
-
-
-    public void updatehasReply(Boolean hasReply) {
-        this.hasReply = hasReply;
-    }
-
-    public void updateParentCommentOrder(Long parentCommentOrder) {
-        this.parentCommentOrder = parentCommentOrder;
-    }
-
-    public void increaseChildCommentCount() {
-        this.childCommentCount++;
-    }
-
 
     @Override
     public boolean equals(Object o) {
@@ -98,5 +63,4 @@ public class Comment extends AuditingFields {
     public int hashCode() {
         return Objects.hash(commentId);
     }
-
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentRequest.java
@@ -11,7 +11,7 @@ public class CommentRequest {
     public static class saveDTO {
         @NotBlank(message = "댓글 내용은 필수입니다.")
         private final String content;
-        private final Long parentCommentId;  // 대댓글의 경우 부모 댓글의 Id 일반 댓글은 null.
+        private final Integer group;  // 대댓글의 경우 원댓글의 group, 일반 댓글은 null로 받음
     }
 
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentRequest.java
@@ -11,7 +11,7 @@ public class CommentRequest {
     public static class saveDTO {
         @NotBlank(message = "댓글 내용은 필수입니다.")
         private final String content;
-        private final Integer group;  // 대댓글의 경우 원댓글의 group, 일반 댓글은 null로 받음
+        private final Integer ref;  // 대댓글의 경우 원댓글의 group, 일반 댓글은 null로 받음
     }
 
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentRequest.java
@@ -11,7 +11,7 @@ public class CommentRequest {
     public static class saveDTO {
         @NotBlank(message = "댓글 내용은 필수입니다.")
         private final String content;
-        private final Long parentCommentOrder;  // 대댓글의 경우 부모 댓글의 commentOrder. 일반 댓글은 null.
+        private final Long parentCommentId;  // 대댓글의 경우 부모 댓글의 Id 일반 댓글은 null.
     }
 
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
@@ -1,24 +1,25 @@
 package com.theocean.fundering.domain.comment.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.theocean.fundering.domain.comment.domain.Comment;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 
 public class CommentResponse {
 
+    // 전체 댓글 조회 DTO
     @Getter
     public static class findAllDTO {
         private final List<commentsDTO> comments;
-
-        @JsonProperty("isLastPage")
+        private final Long lastComment;
         private final boolean isLastPage;
 
-        public findAllDTO(List<commentsDTO> comments, boolean isLastPage) {
+        public findAllDTO(List<commentsDTO> comments, boolean isLastPage, Long lastComment) {
             this.comments = comments;
+            this.lastComment = lastComment;
             this.isLastPage = isLastPage;
         }
 
@@ -26,35 +27,40 @@ public class CommentResponse {
             return isLastPage;
         }
     }
+
+    // findAllDTO의 내부에 들어갈 댓글 정보 DTO
     @Getter
     public static class commentsDTO {
+        private final Long parentComment;
         private final Long commentId;
         private final Long writerId;
         private final String writerName;
         private final String writerProfile;
         private final String content;
-        private final Long parentCommentOrder;
-        private final Long commentOrder;
-
-
-        @JsonProperty("isDeleted")
+        private final boolean isReply;
         private final boolean isDeleted;
-        private final LocalDateTime createdAt;
+        private final long createdAt;
 
         public commentsDTO(Comment comment, String writerName, String writerProfile) {
+            this.parentComment = comment.getParentCommentId();
             this.commentId = comment.getCommentId();
             this.writerId = comment.getWriterId();
             this.writerName = writerName;
             this.writerProfile = writerProfile;
             this.content = comment.getContent();
-            this.parentCommentOrder = comment.getParentCommentOrder();
-            this.commentOrder = comment.getCommentOrder();
-            this.isDeleted = comment.isDeleted();
-            this.createdAt = comment.getCreatedAt();
+            this.isReply = comment.getIsReply();
+            this.isDeleted = comment.getIsDeleted();
+            this.createdAt = toEpochSecond(comment.getCreatedAt());
         }
 
+        private long toEpochSecond(LocalDateTime localDateTime) {
+            return localDateTime.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
+        }
         public boolean getIsDeleted() {
             return isDeleted;
+        }
+        public boolean getIsReply() {
+            return isReply;
         }
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
@@ -13,12 +13,12 @@ public class CommentResponse {
     // 전체 댓글 조회 DTO
     @Getter
     public static class findAllDTO {
-        private final List<commentsDTO> comments;
+        private final List<commentDTO> comments;
         private final Integer groupCursor;
         private final Integer orderCursor;
         private final boolean isLastPage;
 
-        public findAllDTO(List<commentsDTO> comments, Integer groupCursor, Integer orderCursor, boolean isLastPage) {
+        public findAllDTO(List<commentDTO> comments, Integer groupCursor, Integer orderCursor, boolean isLastPage) {
             this.comments = comments;
             this.groupCursor = groupCursor;
             this.orderCursor = orderCursor;
@@ -32,7 +32,7 @@ public class CommentResponse {
 
     // findAllDTO의 내부에 들어갈 댓글 정보 DTO
     @Getter
-    public static class commentsDTO {
+    public static class commentDTO {
         private final Long commentId;
         private final Long writerId;
         private final String writerName;
@@ -44,7 +44,7 @@ public class CommentResponse {
         private final boolean isDeleted;
         private final long createdAt;
 
-        public commentsDTO(Comment comment, String writerName, String writerProfile) {
+        public commentDTO(Comment comment, String writerName, String writerProfile) {
             this.commentId = comment.getCommentId();
             this.writerId = comment.getWriterId();
             this.writerName = writerName;

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
@@ -14,12 +14,14 @@ public class CommentResponse {
     @Getter
     public static class findAllDTO {
         private final List<commentsDTO> comments;
-        private final Long lastComment;
+        private final Integer groupCursor;
+        private final Integer orderCursor;
         private final boolean isLastPage;
 
-        public findAllDTO(List<commentsDTO> comments, boolean isLastPage, Long lastComment) {
+        public findAllDTO(List<commentsDTO> comments, Integer groupCursor, Integer orderCursor, boolean isLastPage) {
             this.comments = comments;
-            this.lastComment = lastComment;
+            this.groupCursor = groupCursor;
+            this.orderCursor = orderCursor;
             this.isLastPage = isLastPage;
         }
 
@@ -31,25 +33,27 @@ public class CommentResponse {
     // findAllDTO의 내부에 들어갈 댓글 정보 DTO
     @Getter
     public static class commentsDTO {
-        private final Long parentComment;
         private final Long commentId;
         private final Long writerId;
         private final String writerName;
         private final String writerProfile;
         private final String content;
-        private final boolean isReply;
+        private final int group;
+        private final int order;
+        private final int depth;
         private final boolean isDeleted;
         private final long createdAt;
 
         public commentsDTO(Comment comment, String writerName, String writerProfile) {
-            this.parentComment = comment.getParentCommentId();
             this.commentId = comment.getCommentId();
             this.writerId = comment.getWriterId();
             this.writerName = writerName;
             this.writerProfile = writerProfile;
             this.content = comment.getContent();
-            this.isReply = comment.getIsReply();
-            this.isDeleted = comment.getIsDeleted();
+            this.group = comment.getGroup();
+            this.order = comment.getOrder();
+            this.depth = comment.getDepth();
+            this.isDeleted = comment.isDeleted();
             this.createdAt = toEpochSecond(comment.getCreatedAt());
         }
 
@@ -58,9 +62,6 @@ public class CommentResponse {
         }
         public boolean getIsDeleted() {
             return isDeleted;
-        }
-        public boolean getIsReply() {
-            return isReply;
         }
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
@@ -14,13 +14,13 @@ public class CommentResponse {
     @Getter
     public static class findAllDTO {
         private final List<commentDTO> comments;
-        private final Integer groupCursor;
+        private final Integer refCursor;
         private final Integer orderCursor;
         private final boolean isLastPage;
 
-        public findAllDTO(List<commentDTO> comments, Integer groupCursor, Integer orderCursor, boolean isLastPage) {
+        public findAllDTO(List<commentDTO> comments, Integer refCursor, Integer orderCursor, boolean isLastPage) {
             this.comments = comments;
-            this.groupCursor = groupCursor;
+            this.refCursor = refCursor;
             this.orderCursor = orderCursor;
             this.isLastPage = isLastPage;
         }
@@ -38,8 +38,8 @@ public class CommentResponse {
         private final String writerName;
         private final String writerProfile;
         private final String content;
-        private final int group;
-        private final int order;
+        private final int ref;
+        private final int refOrder;
         private final int depth;
         private final boolean isDeleted;
         private final long createdAt;
@@ -50,8 +50,8 @@ public class CommentResponse {
             this.writerName = writerName;
             this.writerProfile = writerProfile;
             this.content = comment.getContent();
-            this.group = comment.getGroup();
-            this.order = comment.getOrder();
+            this.ref = comment.getRef();
+            this.refOrder = comment.getRefOrder();
             this.depth = comment.getDepth();
             this.isDeleted = comment.isDeleted();
             this.createdAt = toEpochSecond(comment.getCreatedAt());

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
@@ -2,9 +2,20 @@ package com.theocean.fundering.domain.comment.repository;
 
 import com.theocean.fundering.domain.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    long countByParentCommentId(Long parentCommentId);
+    @Query("SELECT c FROM Comment c WHERE c.postId = :postId AND c.group = :group AND c.order = 0")
+    Optional<Comment> getParentComment(@Param("postId") Long postId, @Param("group") Integer group);
+
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.postId = :postId AND c.group = :group")
+    int countReplies(@Param("postId") Long postId, @Param("group") Integer group);
+
+    @Query("SELECT COALESCE(MAX(c.group), 0) FROM Comment c WHERE c.postId = :postId")
+    int findMaxGroup(@Param("postId") Long postId);
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
@@ -10,12 +10,12 @@ import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    @Query("SELECT c FROM Comment c WHERE c.postId = :postId AND c.group = :group AND c.order = 0")
+    @Query("SELECT c FROM Comment c WHERE c.postId = :postId AND c.ref = :group AND c.refOrder = 0")
     Optional<Comment> getParentComment(@Param("postId") Long postId, @Param("group") Integer group);
 
-    @Query("SELECT COUNT(c) FROM Comment c WHERE c.postId = :postId AND c.group = :group")
+    @Query("SELECT COUNT(c) FROM Comment c WHERE c.postId = :postId AND c.ref = :group")
     int countReplies(@Param("postId") Long postId, @Param("group") Integer group);
 
-    @Query("SELECT COALESCE(MAX(c.group), 0) FROM Comment c WHERE c.postId = :postId")
+    @Query("SELECT COALESCE(MAX(c.ref), 0) FROM Comment c WHERE c.postId = :postId")
     int findMaxGroup(@Param("postId") Long postId);
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CommentRepository.java
@@ -2,25 +2,9 @@ package com.theocean.fundering.domain.comment.repository;
 
 import com.theocean.fundering.domain.comment.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Page;
-
-import java.util.Optional;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    @Query("SELECT COALESCE(MAX(c.commentOrder), 0) FROM Comment c WHERE c.postId = :postId")
-    Long getLastCommentOrder(@Param("postId") Long postId);
-
-    Optional<Comment> findByPostIdAndCommentOrder(Long postId, Long commentOrder);
-
-    @Query("SELECT c FROM Comment c WHERE c.postId = :postId ORDER BY c.parentCommentOrder, c.commentOrder")
-    Page<Comment> findByPostIdOrdered(Long postId, Pageable pageable);
-
-    boolean existsByPostIdAndCommentOrder(Long postId, Long commentOrder);
-
-
+    long countByParentCommentId(Long parentCommentId);
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepository.java
@@ -1,0 +1,9 @@
+package com.theocean.fundering.domain.comment.repository;
+
+import com.theocean.fundering.domain.comment.domain.Comment;
+
+import java.util.List;
+
+public interface CustomCommentRepository {
+    List<Comment> findCommentsByPostId(Long postId, Long lastCommentId, int pageSize);
+}

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepository.java
@@ -5,5 +5,5 @@ import com.theocean.fundering.domain.comment.domain.Comment;
 import java.util.List;
 
 public interface CustomCommentRepository {
-    List<Comment> findCommentsByPostId(Long postId, Long lastCommentId, int pageSize);
+    List<Comment> getCommentList(Long postId, int lastGroup, int lastOrder, int pageSize);
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepositoryImpl.java
@@ -15,16 +15,16 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<Comment> getCommentList(Long postId, int lastGroup, int lastOrder, int pageSize) {
+    public List<Comment> getCommentList(Long postId, int lastRef, int lastOrder, int pageSize) {
         BooleanExpression whereCondition = comment.postId.eq(postId)
                 .andAnyOf(
-                        comment.group.goe(lastGroup).and(comment.order.gt(lastOrder)),
-                        comment.group.gt(lastGroup)
+                        comment.ref.goe(lastRef).and(comment.refOrder.gt(lastOrder)),
+                        comment.ref.gt(lastRef)
                 );
 
         return queryFactory.selectFrom(comment)
                 .where(whereCondition)
-                .orderBy(comment.group.asc(), comment.order.asc())
+                .orderBy(comment.ref.asc(), comment.refOrder.asc())
                 .limit(pageSize)
                 .fetch();
     }

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.theocean.fundering.domain.comment.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.theocean.fundering.domain.comment.domain.Comment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import static com.theocean.fundering.domain.comment.domain.QComment.comment;
+
+@RequiredArgsConstructor
+@Repository
+public class CustomCommentRepositoryImpl implements CustomCommentRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<Comment> findCommentsByPostId(Long postId, Long lastCommentId, int pageSize) {
+        return queryFactory.selectFrom(comment)
+                .where(comment.postId.eq(postId)
+                        .and(comment.commentId.gt(lastCommentId)))
+                .orderBy(
+                        comment.parentCommentId.asc().nullsFirst(),
+                        comment.createdAt.asc()
+                )
+                .limit(pageSize)
+                .fetch();
+    }
+}

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.theocean.fundering.domain.comment.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.theocean.fundering.domain.comment.domain.Comment;
 import lombok.RequiredArgsConstructor;
@@ -14,14 +15,16 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<Comment> findCommentsByPostId(Long postId, Long lastCommentId, int pageSize) {
+    public List<Comment> getCommentList(Long postId, int lastGroup, int lastOrder, int pageSize) {
+        BooleanExpression whereCondition = comment.postId.eq(postId)
+                .andAnyOf(
+                        comment.group.goe(lastGroup).and(comment.order.gt(lastOrder)),
+                        comment.group.gt(lastGroup)
+                );
+
         return queryFactory.selectFrom(comment)
-                .where(comment.postId.eq(postId)
-                        .and(comment.commentId.gt(lastCommentId)))
-                .orderBy(
-                        comment.parentCommentId.asc().nullsFirst(),
-                        comment.createdAt.asc()
-                )
+                .where(whereCondition)
+                .orderBy(comment.group.asc(), comment.order.asc())
                 .limit(pageSize)
                 .fetch();
     }

--- a/src/main/java/com/theocean/fundering/domain/comment/service/CommentService.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/service/CommentService.java
@@ -133,12 +133,12 @@ public class CommentService {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new Exception404("존재하지 않는 댓글입니다: " + commentId));
 
-        // 게시글 존재 여부 확인
+        // 1. 게시글 존재 여부 확인
         if (!postRepository.existsById(postId)) {
             throw new Exception404("해당 게시글을 찾을 수 없습니다: " + postId);
         }
 
-        // 권한 확인
+        // 2. 권한 확인
         if (!comment.getWriterId().equals(memberId)) {
             throw new Exception403("댓글 삭제 권한이 없습니다.");
         }

--- a/src/main/java/com/theocean/fundering/domain/comment/service/CommentService.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/service/CommentService.java
@@ -1,6 +1,7 @@
 package com.theocean.fundering.domain.comment.service;
 
 import com.theocean.fundering.domain.comment.domain.Comment;
+import com.theocean.fundering.domain.comment.repository.CustomCommentRepositoryImpl;
 import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.comment.dto.CommentRequest;
 import com.theocean.fundering.domain.comment.dto.CommentResponse;
@@ -12,8 +13,6 @@ import com.theocean.fundering.global.errors.exception.Exception403;
 import com.theocean.fundering.global.errors.exception.Exception404;
 import com.theocean.fundering.global.errors.exception.Exception500;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +25,7 @@ import java.util.stream.Collectors;
 @Service
 public class CommentService {
 
+    private final CustomCommentRepositoryImpl customCommentRepository;
     private final CommentRepository commentRepository;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
@@ -34,7 +34,7 @@ public class CommentService {
     @Transactional
     public void createComment(Long memberId, Long postId, CommentRequest.saveDTO request) {
 
-        // 댓글 작성 이전 회원과 게시물 존재여부 확인
+        // 1. 댓글 작성 이전 회원과 게시물 존재여부 확인
         if (!memberRepository.existsById(memberId)) {
             throw new Exception400("존재하지 않는 회원입니다: " + memberId);
         }
@@ -43,49 +43,36 @@ public class CommentService {
             throw new Exception404("해당 게시글을 찾을 수 없습니다: " + postId);
         }
 
-        // 댓글 순서 구하는 로직 - 특정 post내에서 가장 최근에 작성된 댓글의 순서 + 1
-        Long commentOrder = commentRepository.getLastCommentOrder(postId) + 1;
 
-        // RequestBody value
-        Long parentCommentOrder = request.getParentCommentOrder();
+        // 요청값
+        Long parentCommentId = request.getParentCommentId();
         String content = request.getContent();
 
-        // Comment 객체 기본 생성
+        // 2. Comment 기본 객체 생성
         Comment newComment = Comment.builder()
                 .writerId(memberId)
                 .postId(postId)
                 .content(content)
-                .commentOrder(commentOrder)
+                .parentCommentId(parentCommentId)
                 .build();
 
-        // 대댓글 생성 로직 (부모 댓글이 존재할 경우)
-        if (parentCommentOrder != null) {
-            Comment parentComment = commentRepository.findByPostIdAndCommentOrder(postId, parentCommentOrder)
-                    .orElseThrow(() -> new Exception400("존재하지 않는 댓글입니다: " + parentCommentOrder));
+        // 3. 완전한 댓글 생성 (대댓글의 경우)
+        if (parentCommentId != null) {
+            Comment parentComment = commentRepository.findById(parentCommentId)
+                    .orElseThrow(() -> new Exception400("존재하지 않는 댓글입니다: " + parentCommentId));
 
-            newComment.updateParentCommentOrder(parentCommentOrder);
-
-            // 부모댓글 업데이트 (대댓글 유무 변경, 대댓글 수 증가)
-            if (!parentComment.isHasReply()) {
-                parentComment.updatehasReply(true);
-            }
-            parentComment.increaseChildCommentCount();
+            newComment.updateIsReply(true);
         }
-        else { // 일반 댓글 생성 로직 (부모 댓글이 존재하지 않을 경우)
-            newComment.updateParentCommentOrder(commentOrder);
+        else {
+            newComment.updateIsReply(false); // 일반 댓글의 경우
         }
 
-        // postId와 commentOrder를 기반으로 중복 검사
-        if (commentRepository.existsByPostIdAndCommentOrder(postId, commentOrder)) {
-            throw new Exception400("댓글 순번이 중복되었습니다: " + commentOrder);
-        }
-
+        // 4. 댓글 저장
         try {
             commentRepository.save(newComment);
         } catch(Exception e) {
             throw new Exception500("댓글 저장 중 문제가 발생했습니다.");
         }
-
     }
 
     // (기능) 댓글 목록 조회 - 유저Id를 이용하여 commentsDTO를 생성하는 로직
@@ -96,34 +83,47 @@ public class CommentService {
         return new CommentResponse.commentsDTO(
                 comment,
                 writer.getNickname(),
-                "ImageURL_Example"
-                //writer.getProfileImage()  // Todo: 유저 ProfileImage필드 추가 이후 리팩토링 예정
+                writer.getProfileImage()
         );
     }
 
 
     // (기능) 댓글 목록 조회 - 컨트롤러로 findAllDTO 리턴
-    public CommentResponse.findAllDTO getCommentsDtoByPostId(long postId, PageRequest pageRequest) {
-
+    public CommentResponse.findAllDTO getCommentsDtoByPostId(long postId, Long lastComment, int pageSize) {
         // 게시글 존재 여부 확인
         if (!postRepository.existsById(postId)) {
             throw new Exception404("해당 게시글을 찾을 수 없습니다: " + postId);
         }
 
-        // 댓글 페이징
-        Page<Comment> commentsPage;
+        List<Comment> comments;
         try {
-            commentsPage = commentRepository.findByPostIdOrdered(postId, pageRequest);
-        }catch(Exception e) {
+            comments = customCommentRepository.findCommentsByPostId(postId, lastComment, pageSize+1);
+        } catch(Exception e) {
             throw new Exception500("댓글 조회 도중 문제가 발생했습니다.");
         }
 
+        // 응답 DTO의 isLastPage부분 - pageSize와 댓글 수가 일치할 때를 위해 하나 더 조회한다
+        boolean isLast = comments.size() <= pageSize;
 
-        List<CommentResponse.commentsDTO> commentsDtos = commentsPage.getContent().stream()
+        if (!isLast) {
+            // 실제로 사용할 댓글은 pageSize 개만
+            comments = comments.subList(0, pageSize);
+        }
+
+        // 응답 DTO의 comments부분
+        List<CommentResponse.commentsDTO> commentsDtos = comments.stream()
                 .map(this::createCommentsDTO)
                 .collect(Collectors.toList());
 
-        return new CommentResponse.findAllDTO(commentsDtos, commentsPage.isLast());
+
+
+        // 응답 DTO의 lastCommentOrder부분
+        Long lastCommentOrder = null;
+        if (!comments.isEmpty()) {
+            lastCommentOrder = comments.get(comments.size() - 1).getCommentOrder();
+        }
+
+        return new CommentResponse.findAllDTO(commentsDtos, isLast, lastCommentOrder);
     }
 
 

--- a/src/main/java/com/theocean/fundering/global/config/security/SpringSecurityConfig.java
+++ b/src/main/java/com/theocean/fundering/global/config/security/SpringSecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,6 +31,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @RequiredArgsConstructor
 @Configuration
+@EnableMethodSecurity
 @EnableWebSecurity
 public class SpringSecurityConfig {
     private final MemberRepository memberRepository;

--- a/src/main/java/com/theocean/fundering/global/errors/GlobalExceptionHandler.java
+++ b/src/main/java/com/theocean/fundering/global/errors/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.theocean.fundering.global.utils.ApiUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -57,6 +58,11 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(apiResult, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<?> accessDeniedError(AccessDeniedException e) {
+        ApiUtils.ApiResult<?> apiResult = ApiUtils.error("접근할 수 없습니다", HttpStatus.FORBIDDEN);
+        return new ResponseEntity<>(apiResult, HttpStatus.FORBIDDEN);
+    }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> unknownServerError(Exception e) {

--- a/src/main/java/com/theocean/fundering/global/jwt/userInfo/CustomUserDetails.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/userInfo/CustomUserDetails.java
@@ -4,9 +4,11 @@ import com.theocean.fundering.domain.member.domain.Member;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Getter
@@ -16,7 +18,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return null;
+        return List.of(new SimpleGrantedAuthority(member.getUserRole().name()));
     }
 
     @Override

--- a/src/test/java/com/theocean/fundering/comment/CommentControllerTest.java
+++ b/src/test/java/com/theocean/fundering/comment/CommentControllerTest.java
@@ -1,0 +1,65 @@
+package com.theocean.fundering.comment;
+
+import com.theocean.fundering.domain.comment.controller.CommentController;
+import com.theocean.fundering.domain.comment.service.CommentService;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(CommentController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+public class CommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CommentService commentService;
+
+
+
+    @WithMockUser(roles = {"USER"})  // USER 권한을 가진 사용자로 설정
+    @Test
+    public void createComment_withUserRole_shouldSucceed() throws Exception {
+
+        this.mockMvc.perform(post("/posts/{postId}/comments", 1L).with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"test comment\"}"))
+                .andExpect(status().isOk());
+    }
+
+    @WithMockUser(roles = "GUEST")  // GUEST 권한을 가진 사용자로 설정
+    @Test
+    public void createComment_withGuestRole_shouldFail() throws Exception {
+        this.mockMvc.perform(post("/posts/{postId}/comments", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"test comment\"}"))
+                .andExpect(status().isForbidden());  // 403 Forbidden 예상
+    }
+
+    @WithMockUser(roles = "USER")  // USER 권한을 가진 사용자로 설정
+    @Test
+    public void deleteComment_withUserRole_shouldSucceed() throws Exception {
+        this.mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", 1L, 1L).with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @WithMockUser(roles = "GUEST")  // GUEST 권한을 가진 사용자로 설정
+    @Test
+    public void deleteComment_withGuestRole_shouldFail() throws Exception {
+        this.mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", 1L, 1L))
+                .andExpect(status().isForbidden());  // 403 Forbidden 예상
+    }
+}


### PR DESCRIPTION
## 주요 사항
- Comment 엔티티 필드값 변경
- 페이징 커서 추가
- 오프셋 페이지네이션 -> 커서기반 페이지네이션
- 조회 DTO 수정
- 댓글 작성과 삭제에 권한 인증 `@PreAuthorize("hasRole('USER')")` 추가
- 권한 거부 예외 처리
- 권한 인증 컨트롤러 테스트 추가


## 스크린샷
![image](https://github.com/Step3-kakao-tech-campus/Team13_BE/assets/79629515/9334d03b-f2f9-427e-8384-ed5f382311f1)
## 궁금한 점
- 프론트 측에서 다음 페이지의 댓글을 조회할 때 데이터가 중복되거나 누락되지 않기 위해서 어디까지 조회를 했는지 알고 있어야 합니다. 저는 기존의 방식에서 아무리 생각해도 정렬을 하면서 올바른 커서를 부여하는 방법을 떠올리지 못했습니다. 그래서 group, order, depth 3가지 필드를 추가하는 방식으로 댓글을 구현했습니다. 프론트 측에 group, order순으로 댓글을 정렬하여 보이고, 동시에 가장 마지막으로 전송한 댓글의 group과 order를 커서로 사용했습니다. 그런데 아무리 생각해도 정렬과 커서를 모두 만족시키는 더 좋은 방식이 있지 않을까라는 의문이 듭니다.

### 관련 이슈
#41 
