### PR TITLE
코드 포맷팅 및 빌드 오류 해결

### DIFF
--- a/src/main/java/com/theocean/fundering/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/post/dto/PostRequest.java
@@ -55,7 +55,7 @@ public class PostRequest {
     @Setter
     @NoArgsConstructor
     @ToString
-    public class PostEditDTO{
+    public static class PostEditDTO{
         private String title;
         private String content;
         private String thumbnail;

--- a/src/test/java/com/theocean/fundering/comment/CommentControllerTest.java
+++ b/src/test/java/com/theocean/fundering/comment/CommentControllerTest.java
@@ -3,13 +3,11 @@ package com.theocean.fundering.comment;
 import com.theocean.fundering.domain.comment.controller.CommentController;
 import com.theocean.fundering.domain.comment.service.CommentService;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
@@ -17,7 +15,11 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@RunWith(SpringRunner.class)
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @WebMvcTest(CommentController.class)
 @MockBean(JpaMetamodelMappingContext.class)
 public class CommentControllerTest {


### PR DESCRIPTION
## 주요 사항
- error: @Builder is not supported on non-static nested classes.
- PostRequest.PostEditDTO의 @Builder 사용을 위해 정적 클래스로 변경


## 스크린샷
<br>

## 궁금한 점
<br>

### 관련 이슈
