### PR TITLE
셀럽 관련 기능 리팩토링

### DIFF
--- a/src/main/java/com/theocean/fundering/domain/celebrity/controller/CelebController.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/controller/CelebController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class CelebController {
     private final CelebService celebService;
-    @PostMapping("/celebs/register")
+    @PostMapping("/celebs")
     public ResponseEntity<?> registerCeleb(@RequestBody @Valid CelebRequestDTO celebRequestDTO, Error error){
         celebService.register(celebRequestDTO);
         return ResponseEntity.ok(ApiUtils.success(null));

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/CelebGender.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/CelebGender.java
@@ -1,6 +1,39 @@
 package com.theocean.fundering.domain.celebrity.domain.constant;
 
+import jakarta.persistence.AttributeConverter;
+
+import java.util.Arrays;
+
 public enum CelebGender {
-    MALE,
-    FEMALE
+    MALE("male"),
+    FEMALE("female");
+
+    private final String type;
+
+    CelebGender(final String type) {
+        this.type = type;
+    }
+    public static CelebGender fromString(final String type) {
+        return Arrays.stream(values())
+                .filter(celebGender -> celebGender.type.equals(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown type: %s".formatted(type)));
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public class CelebTypeToStringConverter implements AttributeConverter<CelebGender, String> {
+
+        @Override
+        public String convertToDatabaseColumn(final CelebGender attribute) {
+            return attribute.getType();
+        }
+
+        @Override
+        public CelebGender convertToEntityAttribute(final String dbData) {
+            return CelebGender.fromString(dbData);
+        }
+    }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/CelebType.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/CelebType.java
@@ -1,10 +1,43 @@
 package com.theocean.fundering.domain.celebrity.domain.constant;
 
+import jakarta.persistence.AttributeConverter;
+
+import java.util.Arrays;
+
 public enum CelebType {
-    SINGER,
-    ACTOR,
-    COMEDIAN,
-    SPORT,
-    INFLUENCER,
-    ETC
+    SINGER("singer"),
+    ACTOR("actor"),
+    COMEDIAN("comedian"),
+    SPORT("sport"),
+    INFLUENCER("influencer"),
+    ETC("etc");
+    private final String type;
+
+    CelebType(final String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public static CelebType fromString(final String type){
+        return Arrays.stream(values())
+                .filter(celebType -> celebType.type.equals(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown type: %s".formatted(type)));
+    }
+
+    public class CelebTypeToStringConverter implements AttributeConverter<CelebType, String>{
+
+        @Override
+        public String convertToDatabaseColumn(CelebType attribute) {
+            return attribute.getType();
+        }
+
+        @Override
+        public CelebType convertToEntityAttribute(String dbData) {
+            return fromString(dbData);
+        }
+    }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebDetailsResponseDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebDetailsResponseDTO.java
@@ -21,7 +21,7 @@ public class CelebDetailsResponseDTO {
         this.celebGroup = celebrity.getCelebGroup();
         this.profileImage = celebrity.getProfileImage();
     }
-    public static CelebDetailsResponseDTO of(Celebrity celebrity){
+    public static CelebDetailsResponseDTO from(Celebrity celebrity){
         return new CelebDetailsResponseDTO(celebrity);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebRequestDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebRequestDTO.java
@@ -19,7 +19,7 @@ public class CelebRequestDTO {
     private String celebGroup;
     private String profileImage;
 
-    public Celebrity getEntity(){
+    public Celebrity mapToEntity(){
         return Celebrity.builder()
                 .celebName(celebName)
                 .celebGender(celebGender)

--- a/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepositoryImpl.java
@@ -12,8 +12,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 import java.util.List;
+import java.util.Objects;
 
-import static com.theocean.fundering.domain.celebrity.domain.QCelebrity.*;
+import static com.theocean.fundering.domain.celebrity.domain.QCelebrity.celebrity;
 import static com.theocean.fundering.domain.post.domain.QPost.post;
 
 @RequiredArgsConstructor
@@ -23,6 +24,7 @@ public class CelebRepositoryImpl implements CelebRepositoryCustom {
 
     @Override
     public Slice<CelebFundingResponseDTO> findAllPosting(final Long celebId, final Long postId, final Pageable pageable) {
+        Objects.requireNonNull(celebId, "celebId must not be null");
         final List<CelebFundingResponseDTO> contents = queryFactory
                 .select(Projections.constructor(CelebFundingResponseDTO.class,
                         post.postId,
@@ -45,6 +47,7 @@ public class CelebRepositoryImpl implements CelebRepositoryCustom {
 
     @Override
     public Slice<CelebListResponseDTO> findAllCeleb(final Long celebId, final Pageable pageable) {
+        Objects.requireNonNull(celebId, "celebId must not be null");
         final List<CelebListResponseDTO> contents = queryFactory
                 .select(Projections.constructor(CelebListResponseDTO.class,
                         celebrity.celebId,

--- a/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepositoryImpl.java
@@ -22,8 +22,8 @@ public class CelebRepositoryImpl implements CelebRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<CelebFundingResponseDTO> findAllPosting(Long celebId, Long postId, Pageable pageable) {
-        List<CelebFundingResponseDTO> contents = queryFactory
+    public Slice<CelebFundingResponseDTO> findAllPosting(final Long celebId, final Long postId, final Pageable pageable) {
+        final List<CelebFundingResponseDTO> contents = queryFactory
                 .select(Projections.constructor(CelebFundingResponseDTO.class,
                         post.postId,
                         post.writer.userId,
@@ -39,16 +39,13 @@ public class CelebRepositoryImpl implements CelebRepositoryCustom {
                 .orderBy(post.postId.desc())
                 .limit(pageable.getPageSize())
                 .fetch();
-        boolean hasNext = false;
-        if(contents.size() > pageable.getPageSize()){
-            hasNext = true;
-        }
+        final boolean hasNext = contents.size() > pageable.getPageSize();
         return new SliceImpl<>(contents, pageable, hasNext);
     }
 
     @Override
-    public Slice<CelebListResponseDTO> findAllCeleb(Long celebId, Pageable pageable) {
-        List<CelebListResponseDTO> contents = queryFactory
+    public Slice<CelebListResponseDTO> findAllCeleb(final Long celebId, final Pageable pageable) {
+        final List<CelebListResponseDTO> contents = queryFactory
                 .select(Projections.constructor(CelebListResponseDTO.class,
                         celebrity.celebId,
                         celebrity.celebName,
@@ -61,27 +58,24 @@ public class CelebRepositoryImpl implements CelebRepositoryCustom {
                 .orderBy(celebrity.celebId.desc())
                 .limit(pageable.getPageSize())
                 .fetch();
-        boolean hasNext = false;
-        if(contents.size() > pageable.getPageSize()){
-            hasNext = true;
-        }
+        final boolean hasNext = contents.size() > pageable.getPageSize();
         return new SliceImpl<>(contents, pageable, hasNext);
     }
 
 
-    private BooleanExpression eqPostCelebId(Long celebId){
+    private BooleanExpression eqPostCelebId(final Long celebId){
         return post.celebrity.celebId.eq(celebId);
     }
 
-    private BooleanExpression ltPostId(Long cursorId){
-        if (cursorId == null){
+    private BooleanExpression ltPostId(final Long cursorId){
+        if (null == cursorId){
             return null;
         }
         return post.postId.lt(cursorId);
     }
 
-    private BooleanExpression ltCelebId(Long cursorId){
-        if (cursorId == null){
+    private BooleanExpression ltCelebId(final Long cursorId){
+        if (null == cursorId){
             return null;
         }
         return celebrity.celebId.lt(cursorId);

--- a/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
@@ -17,7 +17,7 @@ public class CelebService {
     @Transactional
     public void register(CelebRequestDTO celebRequestDTO) {
         try{
-            celebRepository.save(celebRequestDTO.getEntity());
+            celebRepository.save(celebRequestDTO.mapToEntity());
         }catch (Exception e){
             throw new Exception500("셀럽 등록 실패");
         }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
@@ -18,7 +18,7 @@ public class CelebService {
     public void register(CelebRequestDTO celebRequestDTO) {
         try{
             celebRepository.save(celebRequestDTO.mapToEntity());
-        }catch (Exception e){
+        }catch (RuntimeException e){
             throw new Exception500("셀럽 등록 실패");
         }
     }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
@@ -7,7 +7,6 @@ import com.theocean.fundering.global.errors.exception.Exception400;
 import com.theocean.fundering.global.errors.exception.Exception500;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,7 +31,7 @@ public class CelebService {
     public CelebDetailsResponseDTO findByCelebId(Long celebId) {
         Celebrity celebrity = celebRepository.findById(celebId).orElseThrow(
                 () -> new Exception400("해당 셀럽을 찾을 수 없습니다."));
-        return CelebDetailsResponseDTO.of(celebrity);
+        return CelebDetailsResponseDTO.from(celebrity);
     }
 
     public PageResponse<CelebListResponseDTO> findAllCeleb(Long celebId, Pageable pageable) {


### PR DESCRIPTION
## 주요 사항
- RESTFUL API로 변경
  - /celebs/register -> /celebs
- 정적 팩토리 메서드 이름 변경
  - of -> from
  - getEntity -> mapToEntity
- Enum 타입 체크 기능 추가
- 간결한 if문으로 변경
  - code inspection 적용
- 예외 타입 변경
  - Exception -> RuntimeException

### 관련 이슈
#57 
