### PR TITLE
Post Controller, Service, Repository 리팩토링 및 정렬 기능 수정

### DIFF
--- a/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
+++ b/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
@@ -22,16 +22,12 @@ public class Account {
     @ManyToOne
     private Member member;
 
-    @OneToOne
-    private Post post;
-
     @Column
     private int fundingAmount;
 
     @Builder
-    public Account(Member member, Post post, int fundingAmount) {
+    public Account(Member member, int fundingAmount) {
         this.member = member;
-        this.post = post;
         this.fundingAmount = fundingAmount;
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
+++ b/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
@@ -1,16 +1,17 @@
 package com.theocean.fundering.domain.post.controller;
 
 
+import com.theocean.fundering.domain.celebrity.dto.PageResponse;
 import com.theocean.fundering.domain.post.dto.PostRequest;
 import com.theocean.fundering.domain.post.dto.PostResponse;
 import com.theocean.fundering.domain.post.service.PostService;
 import com.theocean.fundering.global.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
 
 
@@ -21,8 +22,8 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping("/posts")
-    public ResponseEntity<?> findAll(@RequestParam(value = "postId", required = false) Long postId, @RequestParam(value = "condition", defaultValue = "DEFAULT") String condition){
-        List<PostResponse.FindAllDTO> responseDTO = postService.findAll(postId, condition);
+    public ResponseEntity<?> findAll(@RequestParam(value = "postId", required = false) Long postId, Pageable pageable){
+        PageResponse<PostResponse.FindAllDTO> responseDTO = postService.findAll(postId, pageable);
         return ResponseEntity.ok(ApiUtils.success(responseDTO));
     }
 
@@ -55,8 +56,8 @@ public class PostController {
     }
 
     @GetMapping("/posts/search")
-    public ResponseEntity<?> searchPost(@RequestParam(value = "postId", required = false) Long postId, @RequestParam(value = "keyword") String keyword){
-        var result = postService.searchPost(postId, keyword);
+    public ResponseEntity<?> searchPost(@RequestParam(value = "postId", required = false) Long postId, @RequestParam(value = "keyword") String keyword, Pageable pageable){
+        var result = postService.searchPost(postId, keyword, pageable);
         return ResponseEntity.ok(ApiUtils.success(result));
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/post/dto/PostResponse.java
@@ -62,7 +62,6 @@ public class PostResponse {
         private LocalDateTime deadline;
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
-        private boolean isLast;
 
         public FindAllDTO(Post post){
             this.postId = post.getPostId();
@@ -77,7 +76,6 @@ public class PostResponse {
             this.deadline = post.getDeadline();
             this.createdAt = post.getCreatedAt();
             this.modifiedAt = post.getModifiedAt();
-            this.isLast = false;
         }
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepository.java
@@ -2,12 +2,14 @@ package com.theocean.fundering.domain.post.repository;
 
 import com.theocean.fundering.domain.post.dto.PostResponse;
 import jakarta.annotation.Nullable;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 
 public interface PostQuerydslRepository {
-    List<PostResponse.FindAllDTO> findAll(@Nullable Long postId, String condition);
+    Slice<PostResponse.FindAllDTO> findAll(@Nullable Long postId, Pageable pageable);
 
-    List<PostResponse.FindAllDTO> findAllByWriterId(@Nullable Long postId, Long writerId);
-    List<PostResponse.FindAllDTO> findAllByKeyword(@Nullable Long postId, String keyword);
+    Slice<PostResponse.FindAllDTO> findAllByWriterId(@Nullable Long postId, Long writerId, Pageable pageable);
+    Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable Long postId, String keyword, Pageable pageable);
 }

--- a/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepositoryImpl.java
@@ -8,6 +8,10 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.theocean.fundering.domain.post.dto.PostResponse;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
 
 
 import static  com.theocean.fundering.domain.post.domain.QPost.post;
@@ -22,10 +26,10 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<PostResponse.FindAllDTO> findAll(@Nullable Long postId, String condition) {
-        OrderSpecifier[] orderSpecifiers = createOrderSpecifier(condition);
+    public Slice<PostResponse.FindAllDTO> findAll(@Nullable Long postId, Pageable pageable) {
+        OrderSpecifier[] orderSpecifiers = createOrderSpecifier(pageable.getSort());
 
-        return jpaQueryFactory
+        List<PostResponse.FindAllDTO> contents =  jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -38,13 +42,19 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .from(post)
                 .where(ltPostId(postId))
                 .orderBy(orderSpecifiers)
-                .limit(12)
+                .limit(pageable.getPageSize())
                 .fetch();
+
+        boolean hasNext = false;
+        if(contents.size() > pageable.getPageSize()){
+            hasNext = true;
+        }
+        return new SliceImpl<>(contents, pageable, hasNext);
     }
 
     @Override
-    public List<PostResponse.FindAllDTO> findAllByWriterId(@Nullable Long postId, Long writerId) {
-        return jpaQueryFactory
+    public Slice<PostResponse.FindAllDTO> findAllByWriterId(@Nullable Long postId, Long writerId, Pageable pageable) {
+        List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -57,12 +67,17 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .from(post)
                 .where(ltPostId(postId), eqWriter(writerId))
                 .orderBy(post.postId.desc())
-                .limit(12)
+                .limit(pageable.getPageSize())
                 .fetch();
+        boolean hasNext = false;
+        if(contents.size() > pageable.getPageSize()){
+            hasNext = true;
+        }
+        return new SliceImpl<>(contents, pageable, hasNext);
     }
     @Override
-    public List<PostResponse.FindAllDTO> findAllByKeyword(@Nullable Long postId, String keyword){
-        return jpaQueryFactory
+    public Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable Long postId, String keyword, Pageable pageable){
+        List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -75,22 +90,27 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .from(post)
                 .where(ltPostId(postId), containKeyword(keyword))
                 .orderBy(post.postId.desc())
-                .limit(12)
+                .limit(pageable.getPageSize())
                 .fetch();
+        boolean hasNext = false;
+        if(contents.size() > pageable.getPageSize()){
+            hasNext = true;
+        }
+        return new SliceImpl<>(contents, pageable, hasNext);
     }
 
-    private OrderSpecifier[] createOrderSpecifier(String condition){
+    private OrderSpecifier[] createOrderSpecifier(Sort sort){
         List<OrderSpecifier> specifiers = new ArrayList<>();
 
         /* 정렬 조건 추가 시 추가 작성
         * */
-        if(Objects.equals(condition, "DEFAULT"))
-            specifiers.add(new OrderSpecifier(Order.DESC, post.postId));
-        else if(Objects.equals(condition, "DEADLINE"))
+        if (sort.toString().equals("recent")) {
+            specifiers.add(new OrderSpecifier(Order.DESC, post.createdAt));
+        } else if(sort.toString().equals("deadline")) {
             specifiers.add(new OrderSpecifier(Order.DESC, post.deadline));
-        else if(Objects.equals(condition, "AMOUNT"))
+        } else if(sort.toString().equals("amount")){
             specifiers.add(new OrderSpecifier(Order.DESC, post.account.fundingAmount));
-
+        }
         return specifiers.toArray(new OrderSpecifier[specifiers.size()]);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/service/PostService.java
+++ b/src/main/java/com/theocean/fundering/domain/post/service/PostService.java
@@ -2,6 +2,7 @@ package com.theocean.fundering.domain.post.service;
 
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
+import com.theocean.fundering.domain.celebrity.dto.PageResponse;
 import com.theocean.fundering.domain.celebrity.repository.CelebRepository;
 import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
@@ -13,10 +14,10 @@ import com.theocean.fundering.global.utils.AWSS3Uploader;
 import jakarta.annotation.Nullable;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 
 @Transactional
@@ -42,20 +43,15 @@ public class PostService {
 
     }
 
-    public List<PostResponse.FindAllDTO> findAll(@Nullable Long postId, String condition){
-        var postList = postRepository.findAll(postId, condition);
-        var checkForNext = postRepository.findAll(postList.get(postList.size() - 1).getPostId() + 1, condition);
-        if (checkForNext == null)
-            postList.get(postList.size() - 1).setLast(true);
-        return postList;
+    public PageResponse<PostResponse.FindAllDTO> findAll(@Nullable Long postId, Pageable pageable){
+        var postList = postRepository.findAll(postId, pageable);
+        return new PageResponse<>(postList);
+
     }
 
-    public List<PostResponse.FindAllDTO> findAllByWriterId(@Nullable Long postId, Long writerId){
-        var postList = postRepository.findAllByWriterId(postId, writerId);
-        var checkForNext = postRepository.findAllByWriterId(postList.get(postList.size() - 1).getPostId() + 1, writerId);
-        if (checkForNext == null)
-            postList.get(postList.size() - 1).setLast(true);
-        return postList;
+    public PageResponse<PostResponse.FindAllDTO> findAllByWriterId(@Nullable Long postId, Long writerId, Pageable pageable){
+        var postList = postRepository.findAllByWriterId(postId, writerId, pageable);
+        return new PageResponse<>(postList);
     }
     @Transactional
     public Long editPost(Long postId, PostRequest.PostEditDTO dto, @Nullable MultipartFile thumbnail){
@@ -70,12 +66,9 @@ public class PostService {
         postRepository.deleteById(postId);
     }
 
-    public List<PostResponse.FindAllDTO> searchPost(@Nullable Long postId, String keyword){
-        var postList = postRepository.findAllByKeyword(postId, keyword);
-        var checkForNext = postRepository.findAllByKeyword(postList.get(postList.size() - 1).getPostId() + 1, keyword);
-        if (checkForNext == null)
-            postList.get(postList.size() - 1).setLast(true);
-        return postList;
+    public PageResponse<PostResponse.FindAllDTO> searchPost(@Nullable Long postId, String keyword, Pageable pageable){
+        var postList = postRepository.findAllByKeyword(postId, keyword, pageable);
+        return new PageResponse<>(postList);
 
     }
 


### PR DESCRIPTION
## 주요 사항
- PostController, PostService, PostQuerydslRepositoryImpl에 Pageable 적용
- 기존의 String 타입의 요청으로 처리하던 정렬 기능 Pageable의 Sort로 정렬하도록 수정

## 스크린샷

## 궁금한 점
Sort 클래스를 toString()을 통해 문자열로 바꿔 OrderSpecifier로 변환하고 있는데, 더 좋은 방법이 있을 것 같아 관련 부분 피드백 해주시면 감사하겠습니다.

### 관련 이슈
#65 
