### PR TITLE
코드 컨벤션 통일 및 API 리턴 타입 변경

### DIFF
--- a/src/main/java/com/theocean/fundering/FunderingApplication.java
+++ b/src/main/java/com/theocean/fundering/FunderingApplication.java
@@ -8,8 +8,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @SpringBootApplication
 public class FunderingApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(FunderingApplication.class, args);
-	}
+    public static void main(final String[] args) {
+        SpringApplication.run(FunderingApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/theocean/fundering/FunderingApplication.java
+++ b/src/main/java/com/theocean/fundering/FunderingApplication.java
@@ -2,13 +2,12 @@ package com.theocean.fundering;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class FunderingApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(FunderingApplication.class, args);
-	}
+    public static void main(final String[] args) {
+        SpringApplication.run(FunderingApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/theocean/fundering/domain/account/controller/AccountController.java
+++ b/src/main/java/com/theocean/fundering/domain/account/controller/AccountController.java
@@ -2,11 +2,8 @@ package com.theocean.fundering.domain.account.controller;
 
 import com.theocean.fundering.domain.account.dto.BalanceResponse;
 import com.theocean.fundering.domain.account.service.AccountService;
-import com.theocean.fundering.domain.comment.dto.CommentResponse;
 import com.theocean.fundering.global.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,11 +17,11 @@ public class AccountController {
 
     // (기능) 펀딩 출금가능 금액 조회
     @GetMapping("/posts/{postId}/balance")
-    public ResponseEntity<?> getFundingBalance(@PathVariable long postId) {
+    public ResponseEntity<?> getFundingBalance(@PathVariable final long postId) {
 
         final int balance = accountService.getBalance(postId);
-        BalanceResponse balanceResponse = new BalanceResponse(balance);
+        final BalanceResponse balanceResponse = new BalanceResponse(balance);
 
-       return ResponseEntity.ok(ApiUtils.success(balanceResponse));
+        return ResponseEntity.ok(ApiUtils.success(balanceResponse));
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
+++ b/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
@@ -1,6 +1,5 @@
 package com.theocean.fundering.domain.account.domain;
 
-import com.theocean.fundering.domain.member.domain.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -34,20 +33,21 @@ public class Account {
     private int balance;
 
     @Builder
-    public Account( final Long managerId, final int fundingAmount){
-            this.managerId = managerId;
-            this.balance = fundingAmount;
-        }
-
-        @Override
-        public boolean equals ( final Object o){
-            if (this == o) return true;
-            if (!(o instanceof final Account account)) return false;
-            return Objects.equals(accountId, account.accountId);
-        }
-
-        @Override
-        public int hashCode () {
-            return Objects.hash(accountId);
-        }
+    public Account(final Long managerId, final Long postId) {
+        this.managerId = managerId;
+        this.postId = postId;
+        balance = 0;
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof final Account account)) return false;
+        return Objects.equals(accountId, account.accountId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accountId);
+    }
+}

--- a/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
+++ b/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
@@ -1,6 +1,13 @@
 package com.theocean.fundering.domain.account.domain;
 
-import jakarta.persistence.*;
+import com.theocean.fundering.domain.member.domain.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,21 +34,20 @@ public class Account {
     private int balance;
 
     @Builder
-    public Account(final Long managerId, final Long postId) {
-        this.managerId = managerId;
-        this.postId = postId;
-        this.balance = 0;
-    }
+    public Account( final Long managerId, final int fundingAmount){
+            this.managerId = managerId;
+            this.balance = fundingAmount;
+        }
 
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof final Account account)) return false;
-        return Objects.equals(accountId, account.accountId);
-    }
+        @Override
+        public boolean equals ( final Object o){
+            if (this == o) return true;
+            if (!(o instanceof final Account account)) return false;
+            return Objects.equals(accountId, account.accountId);
+        }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(accountId);
+        @Override
+        public int hashCode () {
+            return Objects.hash(accountId);
+        }
     }
-}

--- a/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
+++ b/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
@@ -1,8 +1,13 @@
 package com.theocean.fundering.domain.account.domain;
 
-import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.domain.member.domain.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,15 +31,15 @@ public class Account {
     private int fundingAmount;
 
     @Builder
-    public Account(Member member, int fundingAmount) {
+    public Account(final Member member, final int fundingAmount) {
         this.member = member;
         this.fundingAmount = fundingAmount;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Account account)) return false;
+        if (!(o instanceof final Account account)) return false;
         return Objects.equals(accountId, account.accountId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/account/dto/BalanceResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/account/dto/BalanceResponse.java
@@ -1,13 +1,12 @@
 package com.theocean.fundering.domain.account.dto;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 public class BalanceResponse {
     private final int balance;
 
-    public BalanceResponse(int balance) {
+    public BalanceResponse(final int balance) {
         this.balance = balance;
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/account/service/AccountService.java
+++ b/src/main/java/com/theocean/fundering/domain/account/service/AccountService.java
@@ -2,14 +2,10 @@ package com.theocean.fundering.domain.account.service;
 
 import com.theocean.fundering.domain.account.domain.Account;
 import com.theocean.fundering.domain.account.repository.AccountRepository;
-import com.theocean.fundering.domain.post.domain.Post;
-import com.theocean.fundering.domain.post.repository.PostRepository;
 import com.theocean.fundering.global.errors.exception.Exception404;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/src/main/java/com/theocean/fundering/domain/admin/domain/Admin.java
+++ b/src/main/java/com/theocean/fundering/domain/admin/domain/Admin.java
@@ -1,11 +1,21 @@
 package com.theocean.fundering.domain.admin.domain;
 
 import com.theocean.fundering.domain.account.domain.Account;
-import com.theocean.fundering.global.utils.AuditingFields;
-import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.domain.member.domain.Member;
-import lombok.*;
-import jakarta.persistence.*;
+import com.theocean.fundering.domain.post.domain.Post;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
@@ -33,7 +43,7 @@ public class Admin extends AuditingFields {
 
     // 생성자
     @Builder
-    public Admin(Member member, Post post, Account account) {
+    public Admin(final Member member, final Post post, final Account account) {
         this.member = member;
         this.post = post;
         this.account = account;

--- a/src/main/java/com/theocean/fundering/domain/celebrity/controller/CelebController.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/controller/CelebController.java
@@ -1,44 +1,59 @@
 package com.theocean.fundering.domain.celebrity.controller;
 
-import com.theocean.fundering.domain.celebrity.dto.*;
+import com.theocean.fundering.domain.celebrity.dto.CelebDetailsResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebFundingResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebListResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebRequestDTO;
+import com.theocean.fundering.domain.celebrity.dto.PageResponse;
 import com.theocean.fundering.domain.celebrity.service.CelebService;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
 public class CelebController {
     private final CelebService celebService;
+
     @PostMapping("/celebs")
-    public ResponseEntity<?> registerCeleb(@RequestBody @Valid final CelebRequestDTO celebRequestDTO, final Error error){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> registerCeleb(@RequestBody @Valid final CelebRequestDTO celebRequestDTO, final Error error) {
         celebService.register(celebRequestDTO);
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
+
     @GetMapping("/celebs/{celebId}/posts")
-    public ResponseEntity<?> findAllPosting(@PathVariable final Long celebId,
-                                            @RequestParam final Long postId,
-                                            @PageableDefault final Pageable pageable){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findAllPosting(@PathVariable final Long celebId,
+                                       @RequestParam final Long postId,
+                                       @PageableDefault final Pageable pageable) {
         final PageResponse<CelebFundingResponseDTO> page = celebService.findAllPosting(celebId, postId, pageable);
-        return ResponseEntity.ok(ApiUtils.success(page));
+        return ApiResult.success(page);
     }
 
     @GetMapping("/celebs/{celebId}")
-    public ResponseEntity<?> findByCelebId(@PathVariable final Long celebId){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findByCelebId(@PathVariable final Long celebId) {
         final CelebDetailsResponseDTO responseDTO = celebService.findByCelebId(celebId);
-        return ResponseEntity.ok(ApiUtils.success(responseDTO));
+        return ApiResult.success(responseDTO);
     }
 
     @GetMapping("/celebs")
-    public ResponseEntity<?> findAllCelebs(@RequestParam final Long celebId,
-                                            @RequestParam final String keyword,
-                                            @PageableDefault final Pageable pageable){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findAllCelebs(@RequestParam final Long celebId,
+                                      @RequestParam final String keyword,
+                                      @PageableDefault final Pageable pageable) {
         final PageResponse<CelebListResponseDTO> page = celebService.findAllCeleb(celebId, keyword, pageable);
-        return ResponseEntity.ok(ApiUtils.success(page));
+        return ApiResult.success(page);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/controller/CelebController.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/controller/CelebController.java
@@ -1,18 +1,27 @@
 package com.theocean.fundering.domain.celebrity.controller;
 
-import com.theocean.fundering.domain.celebrity.dto.*;
+import com.theocean.fundering.domain.celebrity.dto.CelebDetailsResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebFundingResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebListResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebRequestDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebsRecommendDTO;
 import com.theocean.fundering.domain.celebrity.service.CelebService;
 import com.theocean.fundering.global.dto.PageResponse;
 import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -20,63 +29,46 @@ import java.util.List;
 @RestController
 public class CelebController {
     private final CelebService celebService;
+
     @PostMapping("/celebs")
-    public ResponseEntity<?> registerCeleb(@RequestBody @Valid final CelebRequestDTO celebRequestDTO, final Error error){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> registerCeleb(@RequestBody @Valid final CelebRequestDTO celebRequestDTO, final Error error) {
         celebService.register(celebRequestDTO);
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/celebs/{celebId}/admin")
-    public ResponseEntity<?> findAllCelebForApproval(@PathVariable final Long celebId,
-                                                     @PageableDefault final Pageable pageable
-    ){
-        PageResponse<CelebListResponseDTO> page = celebService.findAllCelebForApproval(celebId, pageable);
-        return ResponseEntity.ok(ApiUtils.success(page));
-    }
-
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @PostMapping("/celebs/{celebId}/admin")
-    public ResponseEntity<?> approvalCelebrity(@PathVariable final Long celebId){
-        celebService.approvalCelebrity(celebId);
-        return ResponseEntity.ok(ApiUtils.success(null));
-    }
-
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @DeleteMapping("/celebs/{celebId}/admin")
-    public ResponseEntity<?> rejectCelebrity(@PathVariable final Long celebId){
-        celebService.deleteCelebrity(celebId);
-        return ResponseEntity.ok(ApiUtils.success(null));
-    }
 
     @GetMapping("/celebs/{celebId}/posts")
-    public ResponseEntity<?> findAllPosting(@PathVariable final Long celebId,
-                                            @RequestParam final Long postId,
-                                            @PageableDefault final Pageable pageable){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findAllPosting(@PathVariable final Long celebId,
+                                       @RequestParam final Long postId,
+                                       @PageableDefault final Pageable pageable) {
         final PageResponse<CelebFundingResponseDTO> page = celebService.findAllPosting(celebId, postId, pageable);
-        return ResponseEntity.ok(ApiUtils.success(page));
+        return ApiResult.success(page);
     }
 
     @GetMapping("/celebs/{celebId}")
-    public ResponseEntity<?> findByCelebId(@PathVariable final Long celebId){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findByCelebId(@PathVariable final Long celebId) {
         final CelebDetailsResponseDTO responseDTO = celebService.findByCelebId(celebId);
-        return ResponseEntity.ok(ApiUtils.success(responseDTO));
+        return ApiResult.success(responseDTO);
     }
 
     @GetMapping("/celebs")
-    public ResponseEntity<?> findAllCelebs(@RequestParam final Long celebId,
-                                            @RequestParam final String keyword,
-                                            @PageableDefault final Pageable pageable){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findAllCelebs(@RequestParam final Long celebId,
+                                      @RequestParam final String keyword,
+                                      @PageableDefault final Pageable pageable) {
         final PageResponse<CelebListResponseDTO> page = celebService.findAllCeleb(celebId, keyword, pageable);
-        return ResponseEntity.ok(ApiUtils.success(page));
+        return ApiResult.success(page);
     }
 
     @GetMapping("/celebs/recommend")
-    public ResponseEntity<?> findAllRecommendCelebs(
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ){
-        List<CelebsRecommendDTO> responseDTO = celebService.recommendCelebs(userDetails);
-        return ResponseEntity.ok(ApiUtils.success(responseDTO));
+    public ApiResult<?> findAllRecommendCelebs(
+            @AuthenticationPrincipal final CustomUserDetails userDetails
+    ) {
+        final List<CelebsRecommendDTO> responseDTO = celebService.recommendCelebs(userDetails);
+        return ApiResult.success(responseDTO);
     }
 
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/controller/FollowController.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/controller/FollowController.java
@@ -18,8 +18,8 @@ public class FollowController {
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/celebs/{celebId}/follow")
-    public ResponseEntity<?> followCelebs(@PathVariable Long celebId,
-                                          @AuthenticationPrincipal CustomUserDetails userDetails
+    public ResponseEntity<?> followCelebs(@PathVariable final Long celebId,
+                                          @AuthenticationPrincipal final CustomUserDetails userDetails
     ) {
         followService.followCelebs(celebId, userDetails.getId());
         return ResponseEntity.ok(ApiUtils.success(null));
@@ -27,8 +27,8 @@ public class FollowController {
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/celebs/{celebId}/unfollow")
-    public ResponseEntity<?> unfollowCelebs(@PathVariable Long celebId,
-                                            @AuthenticationPrincipal CustomUserDetails userDetails
+    public ResponseEntity<?> unfollowCelebs(@PathVariable final Long celebId,
+                                            @AuthenticationPrincipal final CustomUserDetails userDetails
     ) {
         followService.unFollowCelebs(celebId, userDetails.getId());
         return ResponseEntity.ok(ApiUtils.success(null));

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
@@ -3,10 +3,23 @@ package com.theocean.fundering.domain.celebrity.domain;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebGender;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebType;
 import com.theocean.fundering.domain.follow.domain.Follow;
-import com.theocean.fundering.global.utils.AuditingFields;
 import com.theocean.fundering.domain.post.domain.Post;
-import jakarta.persistence.*;
-import lombok.*;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.List;
 import java.util.Objects;
@@ -48,29 +61,9 @@ public class Celebrity extends AuditingFields {
 
     private boolean isApproved;
 
-    public void changeCelebName(String celebName) {
-        this.celebName = celebName;
-    }
-
-    public void changeCelebGender(CelebGender celebGender) {
-        this.celebGender = celebGender;
-    }
-
-    public void changeCeleType(String celebGroup) {
-        this.celebType = celebType;
-    }
-
-    public void changeCeleGroup(CelebType celebType) {
-        this.celebType = celebType;
-    }
-
-    public void changeProfileImage(String profileImage) {
-        this.profileImage = profileImage;
-    }
-
     @Builder
-    public Celebrity(String celebName, CelebGender celebGender, CelebType celebType,
-                     String celebGroup, String profileImage) {
+    public Celebrity(final String celebName, final CelebGender celebGender, final CelebType celebType,
+                     final String celebGroup, final String profileImage) {
         this.celebName = celebName;
         this.celebGender = celebGender;
         this.celebType = celebType;
@@ -78,10 +71,30 @@ public class Celebrity extends AuditingFields {
         this.profileImage = profileImage;
     }
 
+    public void changeCelebName(final String celebName) {
+        this.celebName = celebName;
+    }
+
+    public void changeCelebGender(final CelebGender celebGender) {
+        this.celebGender = celebGender;
+    }
+
+    public void changeCeleType(final String celebGroup) {
+        celebType = celebType;
+    }
+
+    public void changeCeleGroup(final CelebType celebType) {
+        this.celebType = celebType;
+    }
+
+    public void changeProfileImage(final String profileImage) {
+        this.profileImage = profileImage;
+    }
+
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Celebrity celebrity)) return false;
+        if (!(o instanceof final Celebrity celebrity)) return false;
         return Objects.equals(celebId, celebrity.celebId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
@@ -3,9 +3,24 @@ package com.theocean.fundering.domain.celebrity.domain;
 import com.theocean.fundering.domain.celebrity.domain.constant.ApprovalStatus;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebGender;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebType;
+import com.theocean.fundering.domain.follow.domain.Follow;
+import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.global.utils.AuditingFields;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.Objects;
 
@@ -39,34 +54,63 @@ public class Celebrity extends AuditingFields {
     @Column(nullable = false)
     private String profileImage;
 
+<<<<<<<HEAD
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ApprovalStatus status = ApprovalStatus.PENDING;
 
-    public Celebrity approvalCelebrity(){
+    public Celebrity approvalCelebrity() {
         status = ApprovalStatus.APPROVED;
         return this;
-    }
+=======
+        @OneToMany(mappedBy = "celebrity")
+        private List<Follow> followers;
+
+        @OneToMany(mappedBy = "celebrity")
+        private List<Post> post;
+
+        private boolean isApproved;
 
     @Builder
-    public Celebrity(String celebName, CelebGender celebGender, CelebType celebType,
-                     String celebGroup, String profileImage) {
-        this.celebName = celebName;
-        this.celebGender = celebGender;
-        this.celebType = celebType;
-        this.celebGroup = celebGroup;
-        this.profileImage = profileImage;
-    }
+    public Celebrity( final String celebName, final CelebGender celebGender, final CelebType celebType,
+        final String celebGroup, final String profileImage){
+            this.celebName = celebName;
+            this.celebGender = celebGender;
+            this.celebType = celebType;
+            this.celebGroup = celebGroup;
+            this.profileImage = profileImage;
+        }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Celebrity celebrity)) return false;
-        return Objects.equals(celebId, celebrity.celebId);
-    }
+        public void changeCelebName ( final String celebName){
+            this.celebName = celebName;
+        }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(celebId);
+        public void changeCelebGender ( final CelebGender celebGender){
+            this.celebGender = celebGender;
+        }
+
+        public void changeCeleType ( final String celebGroup){
+            celebType = celebType;
+>>>>>>>feat
+        }
+
+        public void changeCeleGroup ( final CelebType celebType){
+            this.celebType = celebType;
+        }
+
+        public void changeProfileImage ( final String profileImage){
+            this.profileImage = profileImage;
+        }
+
+        @Override
+        public boolean equals ( final Object o){
+            if (this == o) return true;
+            if (!(o instanceof final Celebrity celebrity)) return false;
+            return Objects.equals(celebId, celebrity.celebId);
+        }
+
+        @Override
+        public int hashCode () {
+            return Objects.hash(celebId);
+        }
     }
-}

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/Celebrity.java
@@ -3,8 +3,6 @@ package com.theocean.fundering.domain.celebrity.domain;
 import com.theocean.fundering.domain.celebrity.domain.constant.ApprovalStatus;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebGender;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebType;
-import com.theocean.fundering.domain.follow.domain.Follow;
-import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.global.utils.AuditingFields;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -14,7 +12,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -54,63 +51,34 @@ public class Celebrity extends AuditingFields {
     @Column(nullable = false)
     private String profileImage;
 
-<<<<<<<HEAD
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private ApprovalStatus status = ApprovalStatus.PENDING;
 
+    @Builder
+    public Celebrity(final String celebName, final CelebGender celebGender, final CelebType celebType,
+                     final String celebGroup, final String profileImage) {
+        this.celebName = celebName;
+        this.celebGender = celebGender;
+        this.celebType = celebType;
+        this.celebGroup = celebGroup;
+        this.profileImage = profileImage;
+    }
+
     public Celebrity approvalCelebrity() {
         status = ApprovalStatus.APPROVED;
         return this;
-=======
-        @OneToMany(mappedBy = "celebrity")
-        private List<Follow> followers;
-
-        @OneToMany(mappedBy = "celebrity")
-        private List<Post> post;
-
-        private boolean isApproved;
-
-    @Builder
-    public Celebrity( final String celebName, final CelebGender celebGender, final CelebType celebType,
-        final String celebGroup, final String profileImage){
-            this.celebName = celebName;
-            this.celebGender = celebGender;
-            this.celebType = celebType;
-            this.celebGroup = celebGroup;
-            this.profileImage = profileImage;
-        }
-
-        public void changeCelebName ( final String celebName){
-            this.celebName = celebName;
-        }
-
-        public void changeCelebGender ( final CelebGender celebGender){
-            this.celebGender = celebGender;
-        }
-
-        public void changeCeleType ( final String celebGroup){
-            celebType = celebType;
->>>>>>>feat
-        }
-
-        public void changeCeleGroup ( final CelebType celebType){
-            this.celebType = celebType;
-        }
-
-        public void changeProfileImage ( final String profileImage){
-            this.profileImage = profileImage;
-        }
-
-        @Override
-        public boolean equals ( final Object o){
-            if (this == o) return true;
-            if (!(o instanceof final Celebrity celebrity)) return false;
-            return Objects.equals(celebId, celebrity.celebId);
-        }
-
-        @Override
-        public int hashCode () {
-            return Objects.hash(celebId);
-        }
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof final Celebrity celebrity)) return false;
+        return Objects.equals(celebId, celebrity.celebId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(celebId);
+    }
+}

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/Follow.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/Follow.java
@@ -1,11 +1,16 @@
 package com.theocean.fundering.domain.celebrity.domain;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-
 
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,13 +23,13 @@ import java.io.Serializable;
         uniqueConstraints = @UniqueConstraint(columnNames = {"celebrity_id", "member_id"}))
 @IdClass(Follow.PK.class)
 @Entity
-public class Follow{
+public class Follow {
     @Id
-    @Column(name="celebrity_id", insertable = false, updatable = false)
+    @Column(name = "celebrity_id", insertable = false, updatable = false)
     private Long celebrityId;
 
     @Id
-    @Column(name="member_id", insertable = false, updatable = false)
+    @Column(name = "member_id", insertable = false, updatable = false)
     private Long memberId;
 
     //Follow 관계의 유일성을 위한 복합키 설정

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/ApprovalStatus.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/ApprovalStatus.java
@@ -13,6 +13,7 @@ public enum ApprovalStatus {
     ApprovalStatus(final String type) {
         this.type = type;
     }
+
     public static ApprovalStatus fromString(final String type) {
         return Arrays.stream(values())
                 .filter(approvalStatus -> approvalStatus.type.equals(type))
@@ -33,7 +34,7 @@ public enum ApprovalStatus {
 
         @Override
         public ApprovalStatus convertToEntityAttribute(final String dbData) {
-            return ApprovalStatus.fromString(dbData);
+            return fromString(dbData);
         }
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/CelebGender.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/CelebGender.java
@@ -13,6 +13,7 @@ public enum CelebGender {
     CelebGender(final String type) {
         this.type = type;
     }
+
     public static CelebGender fromString(final String type) {
         return Arrays.stream(values())
                 .filter(celebGender -> celebGender.type.equals(type))
@@ -33,7 +34,7 @@ public enum CelebGender {
 
         @Override
         public CelebGender convertToEntityAttribute(final String dbData) {
-            return CelebGender.fromString(dbData);
+            return fromString(dbData);
         }
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/CelebType.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/domain/constant/CelebType.java
@@ -17,26 +17,26 @@ public enum CelebType {
         this.type = type;
     }
 
-    public String getType() {
-        return type;
-    }
-
-    public static CelebType fromString(final String type){
+    public static CelebType fromString(final String type) {
         return Arrays.stream(values())
                 .filter(celebType -> celebType.type.equals(type))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unknown type: %s".formatted(type)));
     }
 
-    public class CelebTypeToStringConverter implements AttributeConverter<CelebType, String>{
+    public String getType() {
+        return type;
+    }
+
+    public class CelebTypeToStringConverter implements AttributeConverter<CelebType, String> {
 
         @Override
-        public String convertToDatabaseColumn(CelebType attribute) {
+        public String convertToDatabaseColumn(final CelebType attribute) {
             return attribute.getType();
         }
 
         @Override
-        public CelebType convertToEntityAttribute(String dbData) {
+        public CelebType convertToEntityAttribute(final String dbData) {
             return fromString(dbData);
         }
     }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebDetailsResponseDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebDetailsResponseDTO.java
@@ -21,7 +21,8 @@ public class CelebDetailsResponseDTO {
         celebGroup = celebrity.getCelebGroup();
         profileImage = celebrity.getProfileImage();
     }
-    public static CelebDetailsResponseDTO from(final Celebrity celebrity){
+
+    public static CelebDetailsResponseDTO from(final Celebrity celebrity) {
         return new CelebDetailsResponseDTO(celebrity);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebFundingResponseDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebFundingResponseDTO.java
@@ -1,6 +1,5 @@
 package com.theocean.fundering.domain.celebrity.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebRequestDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebRequestDTO.java
@@ -19,7 +19,7 @@ public class CelebRequestDTO {
     private String celebGroup;
     private String profileImage;
 
-    public Celebrity mapToEntity(){
+    public Celebrity mapToEntity() {
         return Celebrity.builder()
                 .celebName(celebName)
                 .celebGender(celebGender)

--- a/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebRequestDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebRequestDTO.java
@@ -3,7 +3,10 @@ package com.theocean.fundering.domain.celebrity.dto;
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebGender;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebType;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
@@ -16,7 +19,7 @@ public class CelebRequestDTO {
     private String celebGroup;
     private String profileImage;
 
-    public Celebrity mapToEntity(){
+    public Celebrity mapToEntity() {
         return Celebrity.builder()
                 .celebName(celebName)
                 .celebGender(celebGender)

--- a/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebsRecommendDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/dto/CelebsRecommendDTO.java
@@ -12,14 +12,15 @@ public class CelebsRecommendDTO {
     private final int followingCount;
     private final boolean isFollowing;
 
-    private CelebsRecommendDTO(final Celebrity celebrity, int followerCount, boolean following) {
+    private CelebsRecommendDTO(final Celebrity celebrity, final int followerCount, final boolean following) {
         celebId = celebrity.getCelebId();
         celebName = celebrity.getCelebName();
         celebProfile = celebrity.getProfileImage();
         followingCount = followerCount;
         isFollowing = following;
     }
-    public static CelebsRecommendDTO of(Celebrity celebrity, int followerCount, boolean following) {
+
+    public static CelebsRecommendDTO of(final Celebrity celebrity, final int followerCount, final boolean following) {
         return new CelebsRecommendDTO(celebrity, followerCount, following);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/dto/PageResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/dto/PageResponse.java
@@ -1,15 +1,9 @@
 package com.theocean.fundering.domain.celebrity.dto;
 
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 public class PageResponse<T> {
@@ -17,9 +11,9 @@ public class PageResponse<T> {
     private final int currentPage;
     private final boolean isLast;
 
-    public PageResponse(Slice<T> sliceContent) {
-        this.content = sliceContent.getContent();
-        this.currentPage = sliceContent.getNumber() + 1;
-        this.isLast = sliceContent.isLast();
+    public PageResponse(final Slice<T> sliceContent) {
+        content = sliceContent.getContent();
+        currentPage = sliceContent.getNumber() + 1;
+        isLast = sliceContent.isLast();
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepository.java
@@ -3,7 +3,5 @@ package com.theocean.fundering.domain.celebrity.repository;
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface CelebRepository extends JpaRepository<Celebrity, Long>, CelebRepositoryCustom {
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepository.java
@@ -7,6 +7,9 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.Optional;
 
+=======
+        >>>>>>>feat
+
 public interface CelebRepository extends JpaRepository<Celebrity, Long>, CelebRepositoryCustom {
     @Query(value = "SELECT * FROM celebrity order by RAND() limit 3", nativeQuery = true)
     Optional<List<Celebrity>> findAllRandom();

--- a/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepositoryImpl.java
@@ -67,8 +67,10 @@ public class CelebRepositoryImpl implements CelebRepositoryCustom {
         return new SliceImpl<>(contents, pageable, hasNext);
     }
 
+<<<<<<<HEAD
+
     @Override
-    public Slice<CelebListResponseDTO> findAllCelebForApproval(Long celebId, Pageable pageable) {
+    public Slice<CelebListResponseDTO> findAllCelebForApproval(final Long celebId, final Pageable pageable) {
         Objects.requireNonNull(celebId, "celebId must not be null");
         final List<CelebListResponseDTO> contents = queryFactory
                 .select(Projections.constructor(CelebListResponseDTO.class,
@@ -95,21 +97,26 @@ public class CelebRepositoryImpl implements CelebRepositoryCustom {
         return celebrity.status.eq(ApprovalStatus.PENDING);
     }
 
-    private BooleanExpression eqPostCelebId(final Long celebId){
-        return post.celebrity.celebId.eq(celebId);
-    }
+    private BooleanExpression eqPostCelebId(final Long celebId) {
+=======
+        private BooleanExpression eqPostCelebId ( final Long celebId){
+>>>>>>>feat
+            return post.celebrity.celebId.eq(celebId);
+        }
 
-    private BooleanExpression ltPostId(final Long cursorId){
-        return cursorId != null ? post.postId.lt(cursorId) : null;
-    }
+        private BooleanExpression ltPostId ( final Long cursorId){
+            return null != cursorId ? post.postId.lt(cursorId) : null;
+        }
 
-    private BooleanExpression ltCelebId(final Long cursorId){
-        return cursorId != null ? celebrity.celebId.lt(cursorId) : null;
+        private BooleanExpression ltCelebId ( final Long cursorId){
+            return null != cursorId ? celebrity.celebId.lt(cursorId) : null;
+        }
+
+        private BooleanExpression nameCondition ( final String nameCond){
+            return null != nameCond ? celebrity.celebName.contains(nameCond) : null;
+        }
+
+        private BooleanExpression groupCondition ( final String nameCond){
+            return null != nameCond ? celebrity.celebGroup.contains(nameCond) : null;
+        }
     }
-    private BooleanExpression nameCondition(String nameCond){
-        return nameCond != null ? celebrity.celebName.contains(nameCond) : null;
-    }
-    private BooleanExpression groupCondition(String nameCond){
-        return nameCond != null ? celebrity.celebGroup.contains(nameCond) : null;
-    }
-}

--- a/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/repository/CelebRepositoryImpl.java
@@ -65,21 +65,23 @@ public class CelebRepositoryImpl implements CelebRepositoryCustom {
         return new SliceImpl<>(contents, pageable, hasNext);
     }
 
-    private BooleanExpression eqPostCelebId(final Long celebId){
+    private BooleanExpression eqPostCelebId(final Long celebId) {
         return post.celebrity.celebId.eq(celebId);
     }
 
-    private BooleanExpression ltPostId(final Long cursorId){
-        return cursorId != null ? post.postId.lt(cursorId) : null;
+    private BooleanExpression ltPostId(final Long cursorId) {
+        return null != cursorId ? post.postId.lt(cursorId) : null;
     }
 
-    private BooleanExpression ltCelebId(final Long cursorId){
-        return cursorId != null ? celebrity.celebId.lt(cursorId) : null;
+    private BooleanExpression ltCelebId(final Long cursorId) {
+        return null != cursorId ? celebrity.celebId.lt(cursorId) : null;
     }
-    private BooleanExpression nameCondition(String nameCond){
-        return nameCond != null ? celebrity.celebName.contains(nameCond) : null;
+
+    private BooleanExpression nameCondition(final String nameCond) {
+        return null != nameCond ? celebrity.celebName.contains(nameCond) : null;
     }
-    private BooleanExpression groupCondition(String nameCond){
-        return nameCond != null ? celebrity.celebGroup.contains(nameCond) : null;
+
+    private BooleanExpression groupCondition(final String nameCond) {
+        return null != nameCond ? celebrity.celebGroup.contains(nameCond) : null;
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
@@ -1,7 +1,11 @@
 package com.theocean.fundering.domain.celebrity.service;
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
-import com.theocean.fundering.domain.celebrity.dto.*;
+import com.theocean.fundering.domain.celebrity.dto.CelebDetailsResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebFundingResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebListResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebRequestDTO;
+import com.theocean.fundering.domain.celebrity.dto.PageResponse;
 import com.theocean.fundering.domain.celebrity.repository.CelebRepository;
 import com.theocean.fundering.global.errors.exception.Exception400;
 import com.theocean.fundering.global.errors.exception.Exception500;
@@ -14,11 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CelebService {
     private final CelebRepository celebRepository;
+
     @Transactional
     public void register(final CelebRequestDTO celebRequestDTO) {
-        try{
+        try {
             celebRepository.save(celebRequestDTO.mapToEntity());
-        }catch (final RuntimeException e){
+        } catch (final RuntimeException e) {
             throw new Exception500("셀럽 등록 실패");
         }
     }

--- a/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/service/CelebService.java
@@ -1,7 +1,11 @@
 package com.theocean.fundering.domain.celebrity.service;
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
-import com.theocean.fundering.domain.celebrity.dto.*;
+import com.theocean.fundering.domain.celebrity.dto.CelebDetailsResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebFundingResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebListResponseDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebRequestDTO;
+import com.theocean.fundering.domain.celebrity.dto.CelebsRecommendDTO;
 import com.theocean.fundering.domain.celebrity.repository.CelebRepository;
 import com.theocean.fundering.domain.celebrity.repository.FollowRepository;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
@@ -28,6 +32,7 @@ public class CelebService {
     private final FollowRepository followRepository;
 
     private final MemberRepository memberRepository;
+
 
     @Transactional
     public void register(final CelebRequestDTO celebRequestDTO) {

--- a/src/main/java/com/theocean/fundering/domain/celebrity/service/FollowService.java
+++ b/src/main/java/com/theocean/fundering/domain/celebrity/service/FollowService.java
@@ -3,7 +3,6 @@ package com.theocean.fundering.domain.celebrity.service;
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
 import com.theocean.fundering.domain.celebrity.repository.CelebRepository;
 import com.theocean.fundering.domain.celebrity.repository.FollowRepository;
-import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.global.errors.exception.Exception400;
 import com.theocean.fundering.global.errors.exception.Exception500;
 import lombok.RequiredArgsConstructor;
@@ -23,19 +22,20 @@ public class FollowService {
         final Celebrity celebrity = celebRepository.findById(celebId).orElseThrow(
                 () -> new Exception400("해당 셀럽을 찾을 수 없습니다.")
         );
-        try{
+        try {
             followRepository.saveFollow(celebrity.getCelebId(), memberId);
         } catch (final RuntimeException e) {
             throw new Exception500("팔로우에 실패했습니다.");
         }
     }
+
     @Transactional
     public void unFollowCelebs(final Long celebId, final Long memberId) {
 
         final Celebrity celebrity = celebRepository.findById(celebId).orElseThrow(
                 () -> new Exception400("해당 셀럽을 찾을 수 없습니다.")
         );
-        try{
+        try {
             followRepository.saveUnFollow(celebrity.getCelebId(), memberId);
         } catch (final RuntimeException e) {
             throw new Exception500("언팔로우에 실패했습니다.");

--- a/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/controller/CommentController.java
@@ -6,15 +6,21 @@ import com.theocean.fundering.domain.comment.service.CreateCommentService;
 import com.theocean.fundering.domain.comment.service.DeleteCommentService;
 import com.theocean.fundering.domain.comment.service.ReadCommentService;
 import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,66 +33,71 @@ public class CommentController {
     // (기능) 댓글 작성
     @PreAuthorize("hasRole('USER')")
     @PostMapping("/posts/{postId}/comments")
-    public ResponseEntity<?> createComment(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody @Valid CommentRequest.SaveDTO commentRequest,
-            @PathVariable long postId) {
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> createComment(
+            @AuthenticationPrincipal final CustomUserDetails userDetails,
+            @RequestBody @Valid final CommentRequest.SaveDTO commentRequest,
+            @PathVariable final long postId) {
 
-        Long memberId = 1L; // Long memberId = userDetails.getMember().getUserId();
+        final Long memberId = 1L; // Long memberId = userDetails.getMember().getUserId();
         createCommentService.createComment(memberId, postId, commentRequest);
 
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     // (기능) 대댓글 작성
     @PreAuthorize("hasRole('USER')")
     @PostMapping("/posts/{postId}/comments/{commentId}")
-    public ResponseEntity<?> createSubComment(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody @Valid CommentRequest.SaveDTO commentRequest,
-            @PathVariable long postId,
-            @PathVariable long commentId) {
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> createSubComment(
+            @AuthenticationPrincipal final CustomUserDetails userDetails,
+            @RequestBody @Valid final CommentRequest.SaveDTO commentRequest,
+            @PathVariable final long postId,
+            @PathVariable final long commentId) {
 
-        Long memberId = 1L; // Long memberId = userDetails.getMember().getUserId();
+        final Long memberId = 1L; // Long memberId = userDetails.getMember().getUserId();
         createCommentService.createSubComment(memberId, postId, commentId, commentRequest);
 
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     // (기능) 댓글 목록 조회
     @GetMapping("/posts/{postId}/comments")
-    public ResponseEntity<?> readComments(
-            @PathVariable long postId, @PageableDefault(size = 10) Pageable pageable) {
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> readComments(
+            @PathVariable final long postId, @PageableDefault(size = 10) final Pageable pageable) {
 
-        CommentResponse.FindAllDTO response = readCommentService.getComments(postId, pageable);
+        final CommentResponse.FindAllDTO response = readCommentService.getComments(postId, pageable);
 
-        return ResponseEntity.ok(ApiUtils.success(response));
+        return ApiResult.success(response);
     }
 
     // (기능) 대댓글 목록 조회
     @GetMapping("/posts/{postId}/comments/{commentId}")
-    public ResponseEntity<?> readSubComments(
-            @PathVariable long postId,
-            @PathVariable long commentId,
-            @PageableDefault(size = 10) Pageable pageable) {
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> readSubComments(
+            @PathVariable final long postId,
+            @PathVariable final long commentId,
+            @PageableDefault(size = 10) final Pageable pageable) {
 
-        CommentResponse.FindAllDTO response =
+        final CommentResponse.FindAllDTO response =
                 readCommentService.getSubComments(postId, commentId, pageable);
 
-        return ResponseEntity.ok(ApiUtils.success(response));
+        return ApiResult.success(response);
     }
 
     // (기능) 댓글 삭제
     @PreAuthorize("hasRole('USER')")
     @DeleteMapping("/posts/{postId}/comments/{commentId}")
-    public ResponseEntity<?> deleteComment(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable long postId,
-            @PathVariable long commentId) {
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> deleteComment(
+            @AuthenticationPrincipal final CustomUserDetails userDetails,
+            @PathVariable final long postId,
+            @PathVariable final long commentId) {
 
-        Long memberId = 1L; // userDetails.getMember().getUserId();
+        final Long memberId = 1L; // userDetails.getMember().getUserId();
         deleteCommentService.deleteComment(memberId, postId, commentId);
 
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/domain/Comment.java
@@ -1,11 +1,14 @@
 package com.theocean.fundering.domain.comment.domain;
 
 import com.theocean.fundering.global.utils.AuditingFields;
-import jakarta.persistence.*;
-
-import java.time.ZoneId;
-import java.util.Objects;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,13 +16,14 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.ZoneId;
+import java.util.Objects;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @EntityListeners(AuditingEntityListener.class)
-@Table(
-        name = "comment",
-        indexes = {@Index(name = "index_comment_order", columnList = "commentOrder", unique = false)})
+@Table(name = "comment", indexes = @Index(name = "index_comment_order", columnList = "commentOrder", unique = false))
 @SQLDelete(sql = "UPDATE comment SET is_deleted = true WHERE comment_id = ?")
 public class Comment extends AuditingFields {
 
@@ -43,14 +47,14 @@ public class Comment extends AuditingFields {
     private String commentOrder;
 
     @Builder
-    public Comment(Long writerId, Long postId, String content) {
+    public Comment(final Long writerId, final Long postId, final String content) {
         this.writerId = writerId;
         this.postId = postId;
         this.content = content;
-        this.isDeleted = false;
+        isDeleted = false;
     }
 
-    public void updateCommentOrder(String commentOrder) {
+    public void updateCommentOrder(final String commentOrder) {
         this.commentOrder = commentOrder;
     }
 
@@ -59,13 +63,13 @@ public class Comment extends AuditingFields {
     }
 
     public int getDepth() {
-        return (int) commentOrder.chars().filter(ch -> ch == '.').count();
+        return (int) commentOrder.chars().filter(ch -> '.' == ch).count();
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Comment comment)) return false;
+        if (!(o instanceof final Comment comment)) return false;
         return Objects.equals(commentId, comment.commentId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentRequest.java
@@ -3,7 +3,8 @@ package com.theocean.fundering.domain.comment.dto;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
 
 public class CommentRequest {
     @Getter
@@ -13,7 +14,7 @@ public class CommentRequest {
         private final String content;
 
         @JsonCreator
-        public SaveDTO(@JsonProperty("content") String content) {
+        public SaveDTO(@JsonProperty("content") final String content) {
             this.content = content;
         }
     }

--- a/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/dto/CommentResponse.java
@@ -1,10 +1,9 @@
 package com.theocean.fundering.domain.comment.dto;
 
 import com.theocean.fundering.domain.comment.domain.Comment;
+import lombok.Getter;
 
 import java.util.List;
-
-import lombok.Getter;
 
 public class CommentResponse {
 

--- a/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/repository/CustomCommentRepositoryImpl.java
@@ -1,18 +1,17 @@
 package com.theocean.fundering.domain.comment.repository;
 
-import static com.theocean.fundering.domain.comment.domain.QComment.comment;
-
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.theocean.fundering.domain.comment.domain.Comment;
-
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.theocean.fundering.domain.comment.domain.QComment.comment;
 
 @RequiredArgsConstructor
 @Repository
@@ -21,7 +20,7 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Page<Comment> getCommentsPage(Long postId, Pageable pageable) {
+    public Page<Comment> getCommentsPage(final Long postId, final Pageable pageable) {
         final List<Comment> content =
                 queryFactory
                         .selectFrom(comment)
@@ -48,7 +47,7 @@ public class CustomCommentRepositoryImpl implements CustomCommentRepository {
 
     @Override
     public Page<Comment> getSubCommentsPage(
-            Long postId, String parentCommentOrder, Pageable pageable) {
+            final Long postId, final String parentCommentOrder, final Pageable pageable) {
         final List<Comment> content =
                 queryFactory
                         .selectFrom(comment)

--- a/src/main/java/com/theocean/fundering/domain/comment/service/CommentValidator.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/service/CommentValidator.java
@@ -16,10 +16,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class CommentValidator {
 
+    private static final int REPLY_LIMIT = 30;
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
-    private static final int REPLY_LIMIT = 30;
 
     public void validateMemberAndPost(final Long memberId, final Long postId) {
         if (!memberRepository.existsById(memberId))

--- a/src/main/java/com/theocean/fundering/domain/comment/service/CreateCommentService.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/service/CreateCommentService.java
@@ -12,77 +12,81 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class CreateCommentService {
 
-  private final CommentRepository commentRepository;
-  private final CommentValidator commentValidator;
+    private final CommentRepository commentRepository;
+    private final CommentValidator commentValidator;
 
-  /** (기능) 댓글 작성 */
-  @Transactional
-  public void createComment(
-      final Long memberId, final Long postId, final CommentRequest.SaveDTO request) {
+    /**
+     * (기능) 댓글 작성
+     */
+    @Transactional
+    public void createComment(
+            final Long memberId, final Long postId, final CommentRequest.SaveDTO request) {
 
-    commentValidator.validateMemberAndPost(memberId, postId);
+        commentValidator.validateMemberAndPost(memberId, postId);
 
-    final Comment newComment = buildBaseComment(memberId, postId, request.getContent());
+        final Comment newComment = buildBaseComment(memberId, postId, request.getContent());
 
-    createParentComment(postId, newComment);
-  }
-
-  // 기본 댓글 객체 생성
-  private Comment buildBaseComment(final Long memberId, final Long postId, final String content) {
-    return Comment.builder().writerId(memberId).postId(postId).content(content).build();
-  }
-
-  // 원댓글 생성
-  private void createParentComment(final Long postId, final Comment newComment) {
-    final String maxCommentOrder = commentRepository.findMaxCommentOrder(postId);
-    final int newCommentOrder = calculateCommentOrder(maxCommentOrder);
-
-    newComment.updateCommentOrder(String.valueOf(newCommentOrder));
-    commentRepository.save(newComment);
-  }
-
-  // 생성 댓글의 commentOrder 계산
-  private int calculateCommentOrder(final String maxCommentOrder) {
-    if (null != maxCommentOrder) {
-      final String[] parts = maxCommentOrder.split("\\.");
-      return Integer.parseInt(parts[0]) + 1;
+        createParentComment(postId, newComment);
     }
-    return 1;
-  }
 
-  /** (기능) 대댓글 작성 */
-  @Transactional
-  public void createSubComment(
-      final Long memberId,
-      final Long postId,
-      final Long parentCommentId,
-      final CommentRequest.SaveDTO request) {
+    // 기본 댓글 객체 생성
+    private Comment buildBaseComment(final Long memberId, final Long postId, final String content) {
+        return Comment.builder().writerId(memberId).postId(postId).content(content).build();
+    }
 
-    commentValidator.validateMemberAndPost(memberId, postId);
+    // 원댓글 생성
+    private void createParentComment(final Long postId, final Comment newComment) {
+        final String maxCommentOrder = commentRepository.findMaxCommentOrder(postId);
+        final int newCommentOrder = calculateCommentOrder(maxCommentOrder);
 
-    commentValidator.validateCommentExistence(parentCommentId);
+        newComment.updateCommentOrder(String.valueOf(newCommentOrder));
+        commentRepository.save(newComment);
+    }
 
-    final String content = request.getContent();
+    // 생성 댓글의 commentOrder 계산
+    private int calculateCommentOrder(final String maxCommentOrder) {
+        if (null != maxCommentOrder) {
+            final String[] parts = maxCommentOrder.split("\\.");
+            return Integer.parseInt(parts[0]) + 1;
+        }
+        return 1;
+    }
 
-    final Comment newComment = buildBaseComment(memberId, postId, content);
+    /**
+     * (기능) 대댓글 작성
+     */
+    @Transactional
+    public void createSubComment(
+            final Long memberId,
+            final Long postId,
+            final Long parentCommentId,
+            final CommentRequest.SaveDTO request) {
 
-    final String parentCommentOrder = commentValidator.findCommentOrder(parentCommentId);
+        commentValidator.validateMemberAndPost(memberId, postId);
 
-    commentValidator.validateDepthLimit(parentCommentOrder);
+        commentValidator.validateCommentExistence(parentCommentId);
 
-    createChildComment(postId, parentCommentOrder, newComment);
-  }
+        final String content = request.getContent();
 
-  // 대댓글 생성
-  // @CacheEvict(key = "#postId + '_' + #parentCommentOrder", value = "replyCounts")
-  private void createChildComment(
-          final Long postId, final String parentCommentOrder, final Comment newComment) {
+        final Comment newComment = buildBaseComment(memberId, postId, content);
 
-    final int replyCount = commentValidator.validateReplyLimit(postId, parentCommentOrder);
+        final String parentCommentOrder = commentValidator.findCommentOrder(parentCommentId);
 
-    final String newCommentOrder = parentCommentOrder + "." + (replyCount + 1);
+        commentValidator.validateDepthLimit(parentCommentOrder);
 
-    newComment.updateCommentOrder(newCommentOrder);
-    commentRepository.save(newComment);
-  }
+        createChildComment(postId, parentCommentOrder, newComment);
+    }
+
+    // 대댓글 생성
+    // @CacheEvict(key = "#postId + '_' + #parentCommentOrder", value = "replyCounts")
+    private void createChildComment(
+            final Long postId, final String parentCommentOrder, final Comment newComment) {
+
+        final int replyCount = commentValidator.validateReplyLimit(postId, parentCommentOrder);
+
+        final String newCommentOrder = parentCommentOrder + "." + (replyCount + 1);
+
+        newComment.updateCommentOrder(newCommentOrder);
+        commentRepository.save(newComment);
+    }
 }

--- a/src/main/java/com/theocean/fundering/domain/comment/service/ReadCommentService.java
+++ b/src/main/java/com/theocean/fundering/domain/comment/service/ReadCommentService.java
@@ -6,15 +6,14 @@ import com.theocean.fundering.domain.comment.repository.CustomCommentRepositoryI
 import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.global.errors.exception.Exception404;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/src/main/java/com/theocean/fundering/domain/evidence/controller/EvidenceController.java
+++ b/src/main/java/com/theocean/fundering/domain/evidence/controller/EvidenceController.java
@@ -22,7 +22,7 @@ public class EvidenceController {
     @PostMapping("/posts/{postId}/withdrawals/{withdrawalId}")
     public ResponseEntity<?> evidenceUpload(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
-            @RequestPart(value = "image") MultipartFile img,
+            @RequestPart("image") final MultipartFile img,
             @PathVariable final long postId,
             @PathVariable final long withdrawalId) {
 

--- a/src/main/java/com/theocean/fundering/domain/evidence/domain/Evidence.java
+++ b/src/main/java/com/theocean/fundering/domain/evidence/domain/Evidence.java
@@ -1,11 +1,17 @@
 package com.theocean.fundering.domain.evidence.domain;
 
 
-import com.theocean.fundering.global.utils.AuditingFields;
 import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.domain.withdrawal.domain.Withdrawal;
-import jakarta.persistence.*;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,16 +38,16 @@ public class Evidence extends AuditingFields {
     private Post post;
 
     @Builder
-    public Evidence(Withdrawal withdrawal, Member member, Post post) {
+    public Evidence(final Withdrawal withdrawal, final Member member, final Post post) {
         this.withdrawal = withdrawal;
         this.member = member;
         this.post = post;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Evidence evidence)) return false;
+        if (!(o instanceof final Evidence evidence)) return false;
         return Objects.equals(evidenceId, evidence.evidenceId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/evidence/domain/Evidence.java
+++ b/src/main/java/com/theocean/fundering/domain/evidence/domain/Evidence.java
@@ -1,11 +1,15 @@
 package com.theocean.fundering.domain.evidence.domain;
 
 
-import com.theocean.fundering.global.utils.AuditingFields;
 import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.domain.withdrawal.domain.Withdrawal;
-import jakarta.persistence.*;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +19,7 @@ import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "evidence", indexes = {@Index(name = "index_withdrawal", columnList = "withdrawalId", unique = true)})
+@Table(name = "evidence", indexes = @Index(name = "index_withdrawal", columnList = "withdrawalId", unique = true))
 @Entity
 public class Evidence extends AuditingFields {
     @Id
@@ -35,22 +39,30 @@ public class Evidence extends AuditingFields {
     private String url;
 
     @Builder
+<<<<<<<HEAD
+
     public Evidence(Long withdrawalId, Long applicantId, Long postId, String url) {
         this.withdrawalId = withdrawalId;
         this.applicantId = applicantId;
         this.postId = postId;
         this.url = url;
-    }
+=======
+    public Evidence( final Withdrawal withdrawal, final Member member, final Post post){
+            this.withdrawal = withdrawal;
+            this.member = member;
+            this.post = post;
+>>>>>>>feat
+        }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof Evidence evidence)) return false;
-        return Objects.equals(evidenceId, evidence.evidenceId);
-    }
+        @Override
+        public boolean equals ( final Object o){
+            if (this == o) return true;
+            if (!(o instanceof final Evidence evidence)) return false;
+            return Objects.equals(evidenceId, evidence.evidenceId);
+        }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(evidenceId);
+        @Override
+        public int hashCode () {
+            return Objects.hash(evidenceId);
+        }
     }
-}

--- a/src/main/java/com/theocean/fundering/domain/follow/domain/Follow.java
+++ b/src/main/java/com/theocean/fundering/domain/follow/domain/Follow.java
@@ -3,7 +3,12 @@ package com.theocean.fundering.domain.follow.domain;
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
 import com.theocean.fundering.domain.member.domain.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,9 +33,9 @@ public class Follow {
     private Celebrity celebrity;
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Follow follow)) return false;
+        if (!(o instanceof final Follow follow)) return false;
         return Objects.equals(followId, follow.followId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/follow/domain/Follow.java
+++ b/src/main/java/com/theocean/fundering/domain/follow/domain/Follow.java
@@ -1,4 +1,4 @@
-package com.theocean.fundering.domain.like.domain;
+package com.theocean.fundering.domain.follow.domain;
 
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
@@ -6,48 +6,41 @@ import com.theocean.fundering.domain.member.domain.Member;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.util.Objects;
 
+@Getter
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "heart")
+@Table(name = "follow")
 @Entity
-public class Heart {
-
+public class Follow {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long heartId;
+    @GeneratedValue
+    private Long followId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-
     @ManyToOne(fetch = FetchType.LAZY)
-    private Celebrity celeb;
-
-
-    @Builder
-    public Heart(final Member member, final Celebrity celeb) {
-        this.member = member;
-        this.celeb = celeb;
-    }
+    private Celebrity celebrity;
 
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof final Heart heart)) return false;
-        return Objects.equals(heartId, heart.heartId);
+        if (!(o instanceof final Follow follow)) return false;
+        return Objects.equals(followId, follow.followId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(heartId);
+        return Objects.hash(followId);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/like/domain/Heart.java
+++ b/src/main/java/com/theocean/fundering/domain/like/domain/Heart.java
@@ -3,16 +3,21 @@ package com.theocean.fundering.domain.like.domain;
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
 import com.theocean.fundering.domain.member.domain.Member;
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name="heart")
+@Table(name = "heart")
 @Entity
 public class Heart {
 
@@ -29,15 +34,15 @@ public class Heart {
 
 
     @Builder
-    public Heart(Member member, Celebrity celeb) {
+    public Heart(final Member member, final Celebrity celeb) {
         this.member = member;
         this.celeb = celeb;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Heart heart)) return false;
+        if (!(o instanceof final Heart heart)) return false;
         return Objects.equals(heartId, heart.heartId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/member/controller/MemberController.java
+++ b/src/main/java/com/theocean/fundering/domain/member/controller/MemberController.java
@@ -1,16 +1,17 @@
 package com.theocean.fundering.domain.member.controller;
 
 import com.theocean.fundering.domain.member.dto.EmailRequestDTO;
-import com.theocean.fundering.domain.member.service.MemberService;
 import com.theocean.fundering.domain.member.dto.MemberRequestDTO;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.domain.member.service.MemberService;
+import com.theocean.fundering.global.utils.ApiResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -19,21 +20,24 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup/check")
-    public ResponseEntity<?> checkEmail(@RequestBody @Valid final EmailRequestDTO emailRequestDTO , Error error){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> checkEmail(@RequestBody @Valid final EmailRequestDTO emailRequestDTO, final Error error) {
         memberService.sameCheckEmail(emailRequestDTO.getEmail());
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<?> signUp(@RequestBody @Valid final MemberRequestDTO requestDTO, Error error){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> signUp(@RequestBody @Valid final MemberRequestDTO requestDTO, final Error error) {
         memberService.signUp(requestDTO);
-        return ResponseEntity.ok().body(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/member")
-    public ResponseEntity<?> member(){
-        return ResponseEntity.ok().body(ApiUtils.success(null));
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> member() {
+        return ApiResult.success(null);
     }
 
 //    @PostMapping("/login")

--- a/src/main/java/com/theocean/fundering/domain/member/controller/MemberController.java
+++ b/src/main/java/com/theocean/fundering/domain/member/controller/MemberController.java
@@ -1,17 +1,26 @@
 package com.theocean.fundering.domain.member.controller;
 
 import com.theocean.fundering.domain.member.dto.EmailRequestDTO;
+import com.theocean.fundering.domain.member.dto.MemberRequestDTO;
 import com.theocean.fundering.domain.member.dto.MemberSettingRequestDTO;
-import com.theocean.fundering.domain.member.service.MemberService;
 import com.theocean.fundering.domain.member.dto.MemberSignUpRequestDTO;
+import com.theocean.fundering.domain.member.service.MemberService;
 import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
+import com.theocean.fundering.global.utils.ApiResult;
 import com.theocean.fundering.global.utils.ApiUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+>>>>>>>feat
 
 @RequiredArgsConstructor
 @RestController
@@ -19,49 +28,57 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup/check")
-    public ResponseEntity<?> checkEmail(@RequestBody @Valid final EmailRequestDTO emailRequestDTO , Error error){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> checkEmail(@RequestBody @Valid final EmailRequestDTO emailRequestDTO, final Error error) {
         memberService.sameCheckEmail(emailRequestDTO.getEmail());
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<?> signUp(@RequestBody @Valid final MemberSignUpRequestDTO requestDTO, Error error){
-        memberService.signUp(requestDTO);
-        return ResponseEntity.ok().body(ApiUtils.success(null));
-    }
+<<<<<<<HEAD
 
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("/user/setting")
-    public ResponseEntity<?> findAllUserSetting(
-            @AuthenticationPrincipal final CustomUserDetails userDetails
+    public ResponseEntity<?> signUp(@RequestBody @Valid final MemberSignUpRequestDTO requestDTO, Error error) {
+=======
+        @ResponseStatus(HttpStatus.OK)
+        public ApiResult<?> signUp ( @RequestBody @Valid final MemberRequestDTO requestDTO, final Error error){
+>>>>>>>feat
+            memberService.signUp(requestDTO);
+            return ApiResult.success(null);
+        }
+
+        @PreAuthorize("hasRole('ROLE_USER')")
+        @GetMapping("/user/setting")
+        public ResponseEntity<?> findAllUserSetting (
+        @AuthenticationPrincipal final CustomUserDetails userDetails
     ){
-        var responseDTO = memberService.findAllUserSetting(userDetails.getId());
-        return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
-    }
+            var responseDTO = memberService.findAllUserSetting(userDetails.getId());
+            return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
+        }
 
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @PutMapping("/user/setting")
-    public ResponseEntity<?> modifyUserSetting(
-            @RequestBody @Valid final MemberSettingRequestDTO requestDTO, Error error,
-            @AuthenticationPrincipal final CustomUserDetails userDetails
+        @PreAuthorize("hasRole('ROLE_USER')")
+        @PutMapping("/user/setting")
+        public ResponseEntity<?> modifyUserSetting (
+        @RequestBody @Valid final MemberSettingRequestDTO requestDTO, Error error,
+        @AuthenticationPrincipal final CustomUserDetails userDetails
     ){
-        memberService.modifyUserSetting(requestDTO, userDetails.getId());
-        return ResponseEntity.ok().body(ApiUtils.success("성공적으로 변경되었습니다."));
-    }
+            memberService.modifyUserSetting(requestDTO, userDetails.getId());
+            return ResponseEntity.ok().body(ApiUtils.success("성공적으로 변경되었습니다."));
+        }
 
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @DeleteMapping("/user/setting/cancellation")
-    public ResponseEntity<?> cancellationUser(
-            @AuthenticationPrincipal final CustomUserDetails userDetails
+        @PreAuthorize("hasRole('ROLE_USER')")
+        @DeleteMapping("/user/setting/cancellation")
+        public ResponseEntity<?> cancellationUser (
+        @AuthenticationPrincipal final CustomUserDetails userDetails
     ){
-        memberService.cancellationUser(userDetails.getId());
-        return ResponseEntity.ok().body(ApiUtils.success("회원 탈퇴 되었습니다."));
-    }
+            memberService.cancellationUser(userDetails.getId());
+            return ResponseEntity.ok().body(ApiUtils.success("회원 탈퇴 되었습니다."));
+        }
 
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("/member")
-    public ResponseEntity<?> member(){
-        return ResponseEntity.ok().body(ApiUtils.success(null));
-    }
+        @PreAuthorize("hasRole('ROLE_USER')")
+        @GetMapping("/member")
+        @ResponseStatus(HttpStatus.OK)
+        public ApiResult<?> member () {
+            return ApiResult.success(null);
+        }
 
-}
+    }

--- a/src/main/java/com/theocean/fundering/domain/member/domain/Member.java
+++ b/src/main/java/com/theocean/fundering/domain/member/domain/Member.java
@@ -1,9 +1,22 @@
 package com.theocean.fundering.domain.member.domain;
 
-import com.theocean.fundering.global.utils.AuditingFields;
 import com.theocean.fundering.domain.member.domain.constant.UserRole;
-import jakarta.persistence.*;
-import lombok.*;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.util.Objects;
 
@@ -12,7 +25,7 @@ import java.util.Objects;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member",
-    indexes = @Index(columnList = "email", unique = true)
+        indexes = @Index(columnList = "email", unique = true)
 )
 @Entity
 public class Member extends AuditingFields {
@@ -30,7 +43,7 @@ public class Member extends AuditingFields {
     @Column(nullable = false, length = 50)
     private String email;
 
-    @Enumerated(value = EnumType.STRING)
+    @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
     private String socialId; // 로그인한 소셜 타입의 식별자 값 (일반 로그인인 경우 null)
@@ -41,20 +54,8 @@ public class Member extends AuditingFields {
 
     private boolean isAdmin;
 
-    public void changeNickname(String nickname){
-        this.nickname = nickname;
-    }
-
-    public void setPassword(String password){
-        this.password = password;
-    }
-
-    public void updateRefreshToken(String updateRefreshToken) {
-        this.refreshToken = updateRefreshToken;
-    }
-
     @Builder
-    public Member(Long userId, String nickname, String password, String email, UserRole userRole, String profileImage) {
+    public Member(final Long userId, final String nickname, final String password, final String email, final UserRole userRole, final String profileImage) {
         this.userId = userId;
         this.nickname = nickname;
         this.password = password;
@@ -63,10 +64,22 @@ public class Member extends AuditingFields {
         this.userRole = userRole;
     }
 
+    public void changeNickname(final String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+
+    public void updateRefreshToken(final String updateRefreshToken) {
+        refreshToken = updateRefreshToken;
+    }
+
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Member member)) return false;
+        if (!(o instanceof final Member member)) return false;
         return Objects.equals(userId, member.userId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/member/domain/Member.java
+++ b/src/main/java/com/theocean/fundering/domain/member/domain/Member.java
@@ -1,9 +1,22 @@
 package com.theocean.fundering.domain.member.domain;
 
-import com.theocean.fundering.global.utils.AuditingFields;
 import com.theocean.fundering.domain.member.domain.constant.UserRole;
-import jakarta.persistence.*;
-import lombok.*;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.util.Objects;
 
@@ -12,7 +25,7 @@ import java.util.Objects;
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "member",
-    indexes = @Index(columnList = "email", unique = true)
+        indexes = @Index(columnList = "email", unique = true)
 )
 @Entity
 public class Member extends AuditingFields {
@@ -31,9 +44,12 @@ public class Member extends AuditingFields {
     @Column(nullable = false, length = 50)
     private String email;
 
+<<<<<<<HEAD
     @Column(length = 11)
     private int phoneNumber;
 
+=======
+        >>>>>>>feat
     @Enumerated(EnumType.STRING)
     private UserRole userRole;
 
@@ -43,28 +59,9 @@ public class Member extends AuditingFields {
 
     private String profileImage; // 프로필 이미지
 
-    public void changeNickname(final String nickname){
-        this.nickname = nickname;
-    }
+<<<<<<<HEAD
+    private boolean isAdmin;
 
-    public void setPassword(final String password){
-        this.password = password;
-    }
-
-    public void updateRefreshToken(final String updateRefreshToken) {
-        refreshToken = updateRefreshToken;
-    }
-
-    public void changePhoneNumber(final int phoneNumber){
-        this.phoneNumber = phoneNumber;
-    }
-
-
-    public void changeProfileImage(String profileImage) {
-        this.profileImage = profileImage;
-    }
-
-    @Builder
     public Member(final Long userId, final String nickname, final String password, final String email, final UserRole userRole, final String profileImage) {
         this.userId = userId;
         this.nickname = nickname;
@@ -72,6 +69,42 @@ public class Member extends AuditingFields {
         this.email = email;
         this.profileImage = profileImage;
         this.userRole = userRole;
+    }
+
+    public void changeNickname(final String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+
+    public void updateRefreshToken(final String updateRefreshToken) {
+        refreshToken = updateRefreshToken;
+    }
+=======
+
+    public void changePhoneNumber(final int phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
+>>>>>>>feat
+
+    @Builder
+
+    public void changeProfileImage(final String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public void changeNickname(final String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void setPassword(final String password) {
+        this.password = password;
+    }
+
+    public void updateRefreshToken(final String updateRefreshToken) {
+        refreshToken = updateRefreshToken;
     }
 
     @Override

--- a/src/main/java/com/theocean/fundering/domain/member/domain/constant/UserRole.java
+++ b/src/main/java/com/theocean/fundering/domain/member/domain/constant/UserRole.java
@@ -2,7 +2,6 @@ package com.theocean.fundering.domain.member.domain.constant;
 
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebGender;
 import jakarta.persistence.AttributeConverter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 
@@ -11,18 +10,22 @@ public enum UserRole {
     GUEST("GUEST"),
     USER("USER");
     private final String type;
-    UserRole(final String type){
+
+    UserRole(final String type) {
         this.type = type;
     }
+
     public static UserRole fromString(final String type) {
         return Arrays.stream(values())
                 .filter(userRole -> userRole.type.equals(type))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unknown type: %s".formatted(type)));
     }
+
     public String getType() {
         return type;
     }
+
     public class CelebTypeToStringConverter implements AttributeConverter<CelebGender, String> {
 
         @Override
@@ -35,6 +38,7 @@ public enum UserRole {
             return CelebGender.fromString(dbData);
         }
     }
+
     public class UserRoleToStringConverter implements AttributeConverter<UserRole, String> {
 
         @Override
@@ -44,7 +48,7 @@ public enum UserRole {
 
         @Override
         public UserRole convertToEntityAttribute(final String dbData) {
-            return UserRole.fromString(dbData);
+            return fromString(dbData);
         }
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/member/domain/constant/UserRole.java
+++ b/src/main/java/com/theocean/fundering/domain/member/domain/constant/UserRole.java
@@ -2,7 +2,6 @@ package com.theocean.fundering.domain.member.domain.constant;
 
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebGender;
 import jakarta.persistence.AttributeConverter;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 
@@ -11,18 +10,22 @@ public enum UserRole {
     USER("USER"),
     ADMIN("ADMIN");
     private final String type;
-    UserRole(final String type){
+
+    UserRole(final String type) {
         this.type = type;
     }
+
     public static UserRole fromString(final String type) {
         return Arrays.stream(values())
                 .filter(userRole -> userRole.type.equals(type))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Unknown type: %s".formatted(type)));
     }
+
     public String getType() {
         return type;
     }
+
     public class CelebTypeToStringConverter implements AttributeConverter<CelebGender, String> {
 
         @Override
@@ -35,6 +38,7 @@ public enum UserRole {
             return CelebGender.fromString(dbData);
         }
     }
+
     public class UserRoleToStringConverter implements AttributeConverter<UserRole, String> {
 
         @Override
@@ -44,7 +48,7 @@ public enum UserRole {
 
         @Override
         public UserRole convertToEntityAttribute(final String dbData) {
-            return UserRole.fromString(dbData);
+            return fromString(dbData);
         }
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/member/dto/EmailRequestDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/member/dto/EmailRequestDTO.java
@@ -16,7 +16,7 @@ public class EmailRequestDTO {
         this.email = email;
     }
 
-    public static EmailRequestDTO from(final String email){
+    public static EmailRequestDTO from(final String email) {
         return new EmailRequestDTO(email);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/member/dto/MemberRequestDTO.java
@@ -5,7 +5,10 @@ import com.theocean.fundering.domain.member.domain.constant.UserRole;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Builder
@@ -25,14 +28,15 @@ public class MemberRequestDTO {
     @NotEmpty
     private String nickname;
 
-    public static MemberRequestDTO from(Member member){
-        return MemberRequestDTO.builder()
+    public static MemberRequestDTO from(final Member member) {
+        return builder()
                 .email(member.getEmail())
                 .nickname(member.getNickname())
                 .password(member.getPassword())
                 .build();
     }
-    public Member getEntity(){
+
+    public Member getEntity() {
         return Member.builder()
                 .email(email)
                 .nickname(nickname)
@@ -40,8 +44,9 @@ public class MemberRequestDTO {
                 .userRole(UserRole.USER)
                 .build();
     }
-    public void encodePassword(String encodePassword){
-        this.password = encodePassword;
+
+    public void encodePassword(final String encodePassword) {
+        password = encodePassword;
     }
 
 }

--- a/src/main/java/com/theocean/fundering/domain/member/dto/MemberSignUpRequestDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/member/dto/MemberSignUpRequestDTO.java
@@ -5,8 +5,11 @@ import com.theocean.fundering.domain.member.domain.constant.UserRole;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.*;
-import org.hibernate.annotations.AnyKeyJavaClass;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+>>>>>>>feat:src/main/java/com/theocean/fundering/domain/member/dto/MemberRequestDTO.java
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)// 테스트 에러 방지
@@ -25,20 +28,38 @@ public class MemberSignUpRequestDTO {
     @NotEmpty
     private String nickname;
 
-    public static MemberSignUpRequestDTO of(final String email, final String password, final String nickname){
+<<<<<<<HEAD:src/main/java/com/theocean/fundering/domain/member/dto/MemberSignUpRequestDTO.java
+
+    public static MemberSignUpRequestDTO of(final String email, final String password, final String nickname) {
         return new MemberSignUpRequestDTO(email, password, nickname);
     }
 
-    public Member mapToEntity(){
-        return Member.builder()
-                .email(email)
-                .nickname(nickname)
-                .password(password)
-                .userRole(UserRole.USER)
-                .build();
-    }
-    public void encodePassword(final String encodePassword){
-        password = encodePassword;
-    }
+    public Member mapToEntity() {
+=======
+        public static MemberRequestDTO from ( final Member member){
+            return builder()
+                    .email(member.getEmail())
+                    .nickname(member.getNickname())
+                    .password(member.getPassword())
+                    .build();
+        }
 
-}
+        public Member getEntity () {
+>>>>>>>src / main / java / com / theocean / fundering / domain / member / dto / MemberRequestDTO.java
+            return Member.builder()
+                    .email(email)
+                    .nickname(nickname)
+                    .password(password)
+                    .userRole(UserRole.USER)
+                    .build();
+        }
+<<<<<<<src / main / java / com / theocean / fundering / domain / member / dto / MemberSignUpRequestDTO.java
+        public void encodePassword ( final String encodePassword){
+=======
+
+            public void encodePassword ( final String encodePassword){
+>>>>>>>src / main / java / com / theocean / fundering / domain / member / dto / MemberRequestDTO.java
+                password = encodePassword;
+            }
+
+        }

--- a/src/main/java/com/theocean/fundering/domain/member/service/MemberService.java
+++ b/src/main/java/com/theocean/fundering/domain/member/service/MemberService.java
@@ -1,17 +1,13 @@
 package com.theocean.fundering.domain.member.service;
 
-import com.theocean.fundering.domain.member.domain.Member;
-import com.theocean.fundering.domain.member.dto.EmailRequestDTO;
-import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.domain.member.dto.MemberRequestDTO;
+import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.global.errors.exception.Exception400;
 import com.theocean.fundering.global.errors.exception.Exception500;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,17 +17,17 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void signUp(MemberRequestDTO requestDTO) {
+    public void signUp(final MemberRequestDTO requestDTO) {
         sameCheckEmail(requestDTO.getEmail());
         requestDTO.encodePassword(passwordEncoder.encode(requestDTO.getPassword()));
         try {
             memberRepository.save(requestDTO.getEntity());
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw new Exception500("회원가입 실패");
         }
     }
 
-    public void sameCheckEmail(String email) {
+    public void sameCheckEmail(final String email) {
         memberRepository.findByEmail(email)
                 .ifPresent(n -> {
                     throw new Exception400("이메일이 존재합니다.");
@@ -39,7 +35,7 @@ public class MemberService {
 
     }
 
-    public void login(MemberRequestDTO requestDTO) {
+    public void login(final MemberRequestDTO requestDTO) {
     }
 
 }

--- a/src/main/java/com/theocean/fundering/domain/member/service/MemberService.java
+++ b/src/main/java/com/theocean/fundering/domain/member/service/MemberService.java
@@ -1,9 +1,10 @@
 package com.theocean.fundering.domain.member.service;
 
 import com.theocean.fundering.domain.member.domain.Member;
-import com.theocean.fundering.domain.member.dto.MemberSignUpRequestDTO;
+import com.theocean.fundering.domain.member.dto.MemberRequestDTO;
 import com.theocean.fundering.domain.member.dto.MemberSettingRequestDTO;
 import com.theocean.fundering.domain.member.dto.MemberSettingResponseDTO;
+import com.theocean.fundering.domain.member.dto.MemberSignUpRequestDTO;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.global.errors.exception.Exception400;
 import com.theocean.fundering.global.errors.exception.Exception500;
@@ -20,55 +21,73 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
+<<<<<<<HEAD
+
     public void signUp(final MemberSignUpRequestDTO requestDTO) {
         sameCheckEmail(requestDTO.getEmail());
         requestDTO.encodePassword(passwordEncoder.encode(requestDTO.getPassword()));
         try {
             memberRepository.save(requestDTO.mapToEntity());
-        } catch (final Exception e) {
-            throw new Exception500("회원가입 실패");
-        }
-    }
+=======
+            public void signUp ( final MemberRequestDTO requestDTO){
+                sameCheckEmail(requestDTO.getEmail());
+                requestDTO.encodePassword(passwordEncoder.encode(requestDTO.getPassword()));
+                try {
+                    memberRepository.save(requestDTO.getEntity());
+>>>>>>>feat
+                } catch (final Exception e) {
+                    throw new Exception500("회원가입 실패");
+                }
+            }
 
-    public void sameCheckEmail(final String email) {
-        memberRepository.findByEmail(email).ifPresent(n -> {
-                    throw new Exception400("이메일이 존재합니다.");
-                });
-    }
+            public void sameCheckEmail ( final String email){
+<<<<<<<HEAD
+                memberRepository.findByEmail(email).ifPresent(n -> {
+=======
+                    memberRepository.findByEmail(email)
+                            .ifPresent(n -> {
+>>>>>>>feat
+                                throw new Exception400("이메일이 존재합니다.");
+                            });
+                }
 
-    public MemberSettingResponseDTO findAllUserSetting(final Long id) {
-        final Member member = memberRepository.findById(id).orElseThrow(
-                () -> new Exception400("회원을 찾을 수 없습니다.")
-        );
-        return MemberSettingResponseDTO.from(member);
-    }
+                public MemberSettingResponseDTO findAllUserSetting ( final Long id){
+                    final Member member = memberRepository.findById(id).orElseThrow(
+                            () -> new Exception400("회원을 찾을 수 없습니다.")
+                    );
+                    return MemberSettingResponseDTO.from(member);
+                }
 
-    @Transactional
-    public void modifyUserSetting(@Valid final MemberSettingRequestDTO requestDTO, final Long id) {
-        final Member member = memberRepository.findById(id).orElseThrow(
-                () -> new Exception400("회원을 찾을 수 없습니다.")
-        );
-        member.changeNickname(requestDTO.getNickname());
-        member.setPassword(passwordEncoder.encode(requestDTO.getModifyPassword()));
-        member.changePhoneNumber(requestDTO.getPhoneNumber());
-        member.changeProfileImage(requestDTO.getProfileImage());
-        try{
-            memberRepository.save(member);
-        } catch (final Exception e) {
-            throw new Exception500("회원 정보 수정에 실패했습니다.");
-        }
+<<<<<<<HEAD
+                @Transactional
+                public void modifyUserSetting ( @Valid final MemberSettingRequestDTO requestDTO, final Long id){
+                    final Member member = memberRepository.findById(id).orElseThrow(
+                            () -> new Exception400("회원을 찾을 수 없습니다.")
+                    );
+                    member.changeNickname(requestDTO.getNickname());
+                    member.setPassword(passwordEncoder.encode(requestDTO.getModifyPassword()));
+                    member.changePhoneNumber(requestDTO.getPhoneNumber());
+                    member.changeProfileImage(requestDTO.getProfileImage());
+                    try {
+                        memberRepository.save(member);
+                    } catch (final Exception e) {
+                        throw new Exception500("회원 정보 수정에 실패했습니다.");
+                    }
 
-    }
+=======
+                    public void login ( final MemberRequestDTO requestDTO){
+>>>>>>>feat
+                    }
 
-    @Transactional
-    public void cancellationUser(Long userId) {
-        final Member member = memberRepository.findById(userId).orElseThrow(
-                () -> new Exception400("회원을 찾을 수 없습니다.")
-        );
-        try{
-            memberRepository.delete(member);
-        } catch (final Exception e) {
-            throw new Exception500("회원 탈퇴에 실패했습니다.");
-        }
-    }
-}
+                    @Transactional
+                    public void cancellationUser (Long userId){
+                        final Member member = memberRepository.findById(userId).orElseThrow(
+                                () -> new Exception400("회원을 찾을 수 없습니다.")
+                        );
+                        try {
+                            memberRepository.delete(member);
+                        } catch (final Exception e) {
+                            throw new Exception500("회원 탈퇴에 실패했습니다.");
+                        }
+                    }
+                }

--- a/src/main/java/com/theocean/fundering/domain/myfunding/controller/MyFundingController.java
+++ b/src/main/java/com/theocean/fundering/domain/myfunding/controller/MyFundingController.java
@@ -1,6 +1,5 @@
 package com.theocean.fundering.domain.myfunding.controller;
 
-import com.theocean.fundering.domain.myfunding.dto.MyFundingFollowingCelebsDTO;
 import com.theocean.fundering.domain.myfunding.dto.MyFundingHostResponseDTO;
 import com.theocean.fundering.domain.myfunding.dto.MyFundingManagerResponseDTO;
 import com.theocean.fundering.domain.myfunding.dto.MyFundingSupporterResponseDTO;
@@ -19,8 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @RestController
 public class MyFundingController {
@@ -31,7 +28,7 @@ public class MyFundingController {
     public ResponseEntity<?> findAllPostingByHost(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @RequestParam final Long postId,
-            @PageableDefault final Pageable pageable){
+            @PageableDefault final Pageable pageable) {
         final PageResponse<MyFundingHostResponseDTO> page = myFundingService.findAllPostingByHost(userDetails.getId(), postId, pageable);
         return ResponseEntity.ok(ApiUtils.success(page));
     }
@@ -42,7 +39,7 @@ public class MyFundingController {
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @RequestParam final Long postId,
             @PageableDefault final Pageable pageable
-    ){
+    ) {
         final PageResponse<MyFundingSupporterResponseDTO> page = myFundingService.findAllPostingBySupporter(userDetails.getId(), postId, pageable);
         return ResponseEntity.ok(ApiUtils.success(page));
     }
@@ -51,8 +48,8 @@ public class MyFundingController {
     @GetMapping("/myfunding/nickname")
     public ResponseEntity<?> getNickname(
             @AuthenticationPrincipal final CustomUserDetails userDetails
-    ){
-        String nickname = myFundingService.getNickname(userDetails.getId());
+    ) {
+        final String nickname = myFundingService.getNickname(userDetails.getId());
         return ResponseEntity.ok(ApiUtils.success(nickname));
     }
 
@@ -60,8 +57,8 @@ public class MyFundingController {
     @GetMapping("/myfunding/followers")
     public ResponseEntity<?> findFollowingCelebs(
             @AuthenticationPrincipal final CustomUserDetails userDetails
-    ){
-        var followingCelebs = myFundingService.findFollowingCelebs(userDetails.getId());
+    ) {
+        final var followingCelebs = myFundingService.findFollowingCelebs(userDetails.getId());
         return ResponseEntity.ok(ApiUtils.success(followingCelebs));
     }
 
@@ -71,7 +68,7 @@ public class MyFundingController {
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @RequestParam final Long postId,
             @PageableDefault final Pageable pageable
-    ){
+    ) {
         final PageResponse<MyFundingManagerResponseDTO> page = myFundingService.findAllPostingByManager(userDetails.getId(), postId, pageable);
         return ResponseEntity.ok(ApiUtils.success(null));
     }
@@ -80,7 +77,7 @@ public class MyFundingController {
     public ResponseEntity<?> applyWithdrawal(
             @AuthenticationPrincipal final CustomUserDetails userDetails,
             @RequestParam final Long postId
-    ){
+    ) {
         myFundingService.applyWithdrawal(userDetails.getId(), postId);
         return ResponseEntity.ok(ApiUtils.success(null));
     }

--- a/src/main/java/com/theocean/fundering/domain/myfunding/dto/MyFundingFollowingCelebsDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/myfunding/dto/MyFundingFollowingCelebsDTO.java
@@ -14,7 +14,7 @@ public class MyFundingFollowingCelebsDTO {
         celebId = celebrity.getCelebId();
         profileImage = celebrity.getProfileImage();
         celebName = celebrity.getCelebName();
-        this.followerCount = follower;
+        followerCount = follower;
     }
 
     public static MyFundingFollowingCelebsDTO of(final Celebrity celebrity, final int followerCount) {

--- a/src/main/java/com/theocean/fundering/domain/myfunding/dto/MyFundingHostResponseDTO.java
+++ b/src/main/java/com/theocean/fundering/domain/myfunding/dto/MyFundingHostResponseDTO.java
@@ -1,8 +1,6 @@
 package com.theocean.fundering.domain.myfunding.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/theocean/fundering/domain/myfunding/repository/MyFundingRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/myfunding/repository/MyFundingRepository.java
@@ -9,7 +9,9 @@ import org.springframework.data.domain.Slice;
 
 public interface MyFundingRepository {
     Slice<MyFundingHostResponseDTO> findAllPostingByHost(Long userId, Long postId, Pageable pageable);
+
     Slice<MyFundingSupporterResponseDTO> findAllPostingBySupporter(Long userId, Long postId, Pageable pageable);
+
     Slice<MyFundingManagerResponseDTO> findAllPostingByManager(Long userId, Long postId, Pageable pageable);
 
     void applyWithdrawal(Long userId, Long postId);

--- a/src/main/java/com/theocean/fundering/domain/myfunding/repository/MyFundingRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/myfunding/repository/MyFundingRepositoryImpl.java
@@ -15,14 +15,15 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Objects;
 
-import static com.theocean.fundering.domain.payment.domain.QPayment.*;
+import static com.theocean.fundering.domain.payment.domain.QPayment.payment;
 import static com.theocean.fundering.domain.post.domain.QPost.post;
-import static com.theocean.fundering.domain.withdrawal.domain.QWithdrawal.*;
+import static com.theocean.fundering.domain.withdrawal.domain.QWithdrawal.withdrawal;
 
 @RequiredArgsConstructor
 @Repository
-public class MyFundingRepositoryImpl implements MyFundingRepository{
+public class MyFundingRepositoryImpl implements MyFundingRepository {
     private final JPAQueryFactory queryFactory;
+
     @Override
     public Slice<MyFundingHostResponseDTO> findAllPostingByHost(final Long userId, final Long postId, final Pageable pageable) {
         Objects.requireNonNull(postId, "postId must not be null");
@@ -107,11 +108,11 @@ public class MyFundingRepositoryImpl implements MyFundingRepository{
                 .execute();
     }
 
-    private BooleanExpression eqPostWriterId(final Long userId){
+    private BooleanExpression eqPostWriterId(final Long userId) {
         return post.writer.userId.eq(userId);
     }
 
-    private BooleanExpression eqPostSupporterId(final Long userId){
+    private BooleanExpression eqPostSupporterId(final Long userId) {
         return payment.member.userId.eq(userId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/myfunding/service/MyFundingService.java
+++ b/src/main/java/com/theocean/fundering/domain/myfunding/service/MyFundingService.java
@@ -26,6 +26,7 @@ public class MyFundingService {
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
     private final CelebRepository celebRepository;
+
     public PageResponse<MyFundingHostResponseDTO> findAllPostingByHost(final Long userId, final Long postId, final Pageable pageable) {
         final var page = myFundingRepository.findAllPostingByHost(userId, postId, pageable);
         return new PageResponse<>(page);
@@ -46,7 +47,7 @@ public class MyFundingService {
     public List<MyFundingFollowingCelebsDTO> findFollowingCelebs(final Long userId) {
         final List<MyFundingFollowingCelebsDTO> responseDTO = new ArrayList<>();
         final List<Long> allFollowingCelebId = followRepository.findAllFollowingCelebById(userId);
-        for(final Long celebId: allFollowingCelebId){
+        for (final Long celebId : allFollowingCelebId) {
             final Celebrity celebrity = celebRepository.findById(celebId).orElseThrow(
                     () -> new Exception400("셀럽을 찾을 수 없습니다.")
             );
@@ -56,12 +57,12 @@ public class MyFundingService {
         return responseDTO;
     }
 
-    public PageResponse<MyFundingManagerResponseDTO> findAllPostingByManager(Long userId, Long postId, Pageable pageable) {
-        var page = myFundingRepository.findAllPostingByManager(userId, postId, pageable);
+    public PageResponse<MyFundingManagerResponseDTO> findAllPostingByManager(final Long userId, final Long postId, final Pageable pageable) {
+        final var page = myFundingRepository.findAllPostingByManager(userId, postId, pageable);
         return new PageResponse<>(page);
     }
 
-    public void applyWithdrawal(Long userId, Long postId) {
+    public void applyWithdrawal(final Long userId, final Long postId) {
         myFundingRepository.applyWithdrawal(userId, postId);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/news/controller/NewsController.java
+++ b/src/main/java/com/theocean/fundering/domain/news/controller/NewsController.java
@@ -5,11 +5,17 @@ import com.theocean.fundering.domain.news.dto.NewsResponse;
 import com.theocean.fundering.domain.news.service.CreateNewsService;
 import com.theocean.fundering.domain.news.service.ReadNewsService;
 import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,27 +26,29 @@ public class NewsController {
 
     // (기능) 펀딩 업데이트 작성
     @PostMapping("/posts/{postId}/updates")
-    public ResponseEntity<?> createUpdates(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable long postId,
-            @RequestBody NewsRequest.saveDTO request) {
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> createUpdates(
+            @AuthenticationPrincipal final CustomUserDetails userDetails,
+            @PathVariable final long postId,
+            @RequestBody final NewsRequest.saveDTO request) {
 
         // TODO: 추후 리팩토링 예정
-        Long writerId = 1L;
+        final Long writerId = 1L;
         createNewsService.createNews(writerId, postId, request);
 
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     // (기능) 펀딩 업데이트 조회
     @GetMapping("/posts/{postId}/updates")
-    public ResponseEntity<?> readUpdates(
-            @PathVariable long postId,
-            @RequestParam(required = false, defaultValue = "0") long cursor,
-            @RequestParam(required = false, defaultValue = "6") int pageSize) {
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> readUpdates(
+            @PathVariable final long postId,
+            @RequestParam(required = false, defaultValue = "0") final long cursor,
+            @RequestParam(required = false, defaultValue = "6") final int pageSize) {
 
-        NewsResponse.findAllDTO response = readNewsService.getNews(postId, cursor, pageSize);
+        final NewsResponse.findAllDTO response = readNewsService.getNews(postId, cursor, pageSize);
 
-        return ResponseEntity.ok(ApiUtils.success(response));
+        return ApiResult.success(response);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/news/domain/News.java
+++ b/src/main/java/com/theocean/fundering/domain/news/domain/News.java
@@ -1,15 +1,20 @@
 package com.theocean.fundering.domain.news.domain;
 
 import com.theocean.fundering.global.utils.AuditingFields;
-import jakarta.persistence.*;
-
-import java.util.Objects;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -37,21 +42,21 @@ public class News extends AuditingFields {
     private String imageUrls; // TODO: 추후 리팩토링 예정
 
     @Builder
-    public News(Long postId, Long writerId, String title, String content) {
+    public News(final Long postId, final Long writerId, final String title, final String content) {
         this.postId = postId;
         this.writerId = writerId;
         this.title = title;
         this.content = content;
     }
 
-    public void updateImageUrls(String imageUrls) {
+    public void updateImageUrls(final String imageUrls) {
         this.imageUrls = imageUrls;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof News news)) return false;
+        if (!(o instanceof final News news)) return false;
         return Objects.equals(newsId, news.newsId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/news/dto/NewsRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/news/dto/NewsRequest.java
@@ -6,11 +6,11 @@ import lombok.RequiredArgsConstructor;
 
 public class NewsRequest {
 
-  @Getter
-  @Builder
-  @RequiredArgsConstructor
-  public static class saveDTO {
-    private final String title;
-    private final String content; // 마크다운 형식의 문자열이 저장됨
-  }
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    public static class saveDTO {
+        private final String title;
+        private final String content; // 마크다운 형식의 문자열이 저장됨
+    }
 }

--- a/src/main/java/com/theocean/fundering/domain/news/dto/NewsResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/news/dto/NewsResponse.java
@@ -1,46 +1,47 @@
 package com.theocean.fundering.domain.news.dto;
 
 import com.theocean.fundering.domain.news.domain.News;
+import lombok.Getter;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import lombok.Getter;
 
 public class NewsResponse {
-  @Getter
-  public static class findAllDTO {
-    private final List<NewsResponse.newsDTO> updates;
-    private final Long cursor;
-    private final boolean isLastPage;
+    @Getter
+    public static class findAllDTO {
+        private final List<NewsResponse.newsDTO> updates;
+        private final Long cursor;
+        private final boolean isLastPage;
 
-    public findAllDTO(List<NewsResponse.newsDTO> updates, Long cursor, boolean isLastPage) {
-      this.updates = updates;
-      this.cursor = cursor;
-      this.isLastPage = isLastPage;
+        public findAllDTO(final List<NewsResponse.newsDTO> updates, final Long cursor, final boolean isLastPage) {
+            this.updates = updates;
+            this.cursor = cursor;
+            this.isLastPage = isLastPage;
+        }
+
+        public boolean getIsLastPage() {
+            return isLastPage;
+        }
     }
 
-    public boolean getIsLastPage() {
-      return isLastPage;
-    }
-  }
+    // findAllDTO의 내부에 들어갈 업데이트 글 정보 DTO
+    @Getter
+    public static class newsDTO {
+        private final Long updateId;
+        private final String title;
+        private final String content;
+        private final long createdAt;
 
-  // findAllDTO의 내부에 들어갈 업데이트 글 정보 DTO
-  @Getter
-  public static class newsDTO {
-    private final Long updateId;
-    private final String title;
-    private final String content;
-    private final long createdAt;
+        public newsDTO(final News news) {
+            updateId = news.getNewsId();
+            title = news.getTitle();
+            content = news.getContent();
+            createdAt = toEpochSecond(news.getCreatedAt());
+        }
 
-    public newsDTO(News news) {
-      this.updateId = news.getNewsId();
-      this.title = news.getTitle();
-      this.content = news.getContent();
-      this.createdAt = toEpochSecond(news.getCreatedAt());
+        private long toEpochSecond(final LocalDateTime localDateTime) {
+            return localDateTime.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
+        }
     }
-
-    private long toEpochSecond(LocalDateTime localDateTime) {
-      return localDateTime.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
-    }
-  }
 }

--- a/src/main/java/com/theocean/fundering/domain/news/repository/CustomNewsRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/news/repository/CustomNewsRepository.java
@@ -1,8 +1,9 @@
 package com.theocean.fundering.domain.news.repository;
 
 import com.theocean.fundering.domain.news.domain.News;
+
 import java.util.List;
 
 public interface CustomNewsRepository {
-  List<News> getNewsList(long postId, long cursor, int pageSize);
+    List<News> getNewsList(long postId, long cursor, int pageSize);
 }

--- a/src/main/java/com/theocean/fundering/domain/news/repository/CustomNewsRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/news/repository/CustomNewsRepositoryImpl.java
@@ -1,32 +1,33 @@
 package com.theocean.fundering.domain.news.repository;
 
-import static com.theocean.fundering.domain.news.domain.QNews.news;
-
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.theocean.fundering.domain.news.domain.News;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.theocean.fundering.domain.news.domain.QNews.news;
 
 @RequiredArgsConstructor
 @Repository
 public class CustomNewsRepositoryImpl implements CustomNewsRepository {
 
-  private static final long DEFAULT_CURSOR = 0;
-  private final JPAQueryFactory queryFactory;
+    private static final long DEFAULT_CURSOR = 0;
+    private final JPAQueryFactory queryFactory;
 
-  public List<News> getNewsList(long postId, long cursor, int pageSize) {
-    BooleanExpression whereCondition = news.postId.eq(postId);
-    if (cursor > DEFAULT_CURSOR) {
-      whereCondition = whereCondition.and(news.newsId.lt(cursor));
+    public List<News> getNewsList(final long postId, final long cursor, final int pageSize) {
+        BooleanExpression whereCondition = news.postId.eq(postId);
+        if (DEFAULT_CURSOR < cursor) {
+            whereCondition = whereCondition.and(news.newsId.lt(cursor));
+        }
+
+        return queryFactory
+                .selectFrom(news)
+                .where(whereCondition)
+                .orderBy(news.newsId.desc())
+                .limit(pageSize)
+                .fetch();
     }
-
-    return queryFactory
-        .selectFrom(news)
-        .where(whereCondition)
-        .orderBy(news.newsId.desc())
-        .limit(pageSize)
-        .fetch();
-  }
 }

--- a/src/main/java/com/theocean/fundering/domain/news/repository/NewsRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/news/repository/NewsRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface NewsRepository extends JpaRepository<News, Long> {}
+public interface NewsRepository extends JpaRepository<News, Long> {
+}

--- a/src/main/java/com/theocean/fundering/domain/news/service/ReadNewsService.java
+++ b/src/main/java/com/theocean/fundering/domain/news/service/ReadNewsService.java
@@ -6,13 +6,12 @@ import com.theocean.fundering.domain.news.repository.CustomNewsRepositoryImpl;
 import com.theocean.fundering.domain.post.repository.PostRepository;
 import com.theocean.fundering.global.errors.exception.Exception404;
 import com.theocean.fundering.global.errors.exception.Exception500;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/src/main/java/com/theocean/fundering/domain/payment/controller/PaymentController.java
+++ b/src/main/java/com/theocean/fundering/domain/payment/controller/PaymentController.java
@@ -4,20 +4,20 @@ package com.theocean.fundering.domain.payment.controller;
 import com.siot.IamportRestClient.exception.IamportResponseException;
 import com.siot.IamportRestClient.response.IamportResponse;
 import com.siot.IamportRestClient.response.Payment;
-import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.payment.dto.PaymentRequest;
 import com.theocean.fundering.domain.payment.service.PaymentService;
-import com.theocean.fundering.global.jwt.JwtProvider;
 import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
@@ -28,21 +28,21 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/posts/{postId}/verify")
-    public IamportResponse<Payment> verifyByImpUid(@PathVariable Long postId,
-                                                   @RequestParam(value = "imp_uid") String impUid) throws IamportResponseException, IOException {
+    @GetMapping("/posts/{postId}/verify")
+    public IamportResponse<Payment> verifyByImpUid(@PathVariable final Long postId,
+                                                   @RequestParam("imp_uid") final String impUid) throws IamportResponseException, IOException {
         return paymentService.verifyByImpUid(impUid);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/posts/{postId}/donate")
-    public ResponseEntity<?> donate(@PathVariable Long postId,
-                                    @AuthenticationPrincipal CustomUserDetails userDetails,
-                                    @RequestParam(value = "imp_uid") String impUid,
-                                    @RequestBody PaymentRequest.DonateDTO donateDTO){
-        String email = userDetails.getEmail();
-        paymentService.donate(postId, email, impUid, donateDTO);
-        return ResponseEntity.ok(ApiUtils.success(null));
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> donate(@PathVariable final Long postId,
+                               @AuthenticationPrincipal final CustomUserDetails userDetails,
+                               @RequestBody final PaymentRequest.DonateDTO donateDTO) {
+        final String email = userDetails.getEmail();
+        paymentService.donate(postId, email, donateDTO);
+        return ApiResult.success(null);
     }
 
 

--- a/src/main/java/com/theocean/fundering/domain/payment/domain/Payment.java
+++ b/src/main/java/com/theocean/fundering/domain/payment/domain/Payment.java
@@ -1,18 +1,24 @@
 package com.theocean.fundering.domain.payment.domain;
 
-import com.theocean.fundering.global.utils.AuditingFields;
-import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.domain.member.domain.Member;
+import com.theocean.fundering.domain.post.domain.Post;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import jakarta.persistence.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.Objects;
-
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 
 @Getter
@@ -41,7 +47,7 @@ public class Payment extends AuditingFields {
 
     // 생성자
     @Builder
-    public Payment(Member member, Post post, String impUid, Integer amount) {
+    public Payment(final Member member, final Post post, final String impUid, final Integer amount) {
         this.member = member;
         this.post = post;
         this.impUid = impUid;
@@ -49,9 +55,9 @@ public class Payment extends AuditingFields {
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Payment payment)) return false;
+        if (!(o instanceof final Payment payment)) return false;
         return Objects.equals(paymentId, payment.paymentId);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/payment/dto/PaymentRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/payment/dto/PaymentRequest.java
@@ -15,23 +15,26 @@ public class PaymentRequest {
     @Setter
     @NoArgsConstructor
     @ToString
-    public static class DonateDTO{
+    public static class DonateDTO {
         private String member;
         private Integer amount;
+        private String impUid;
 
 
-        public Payment toEntity(Member member, Post post, String impUid){
+        @Builder
+        public DonateDTO(final String member, final Integer amount, final String impUid) {
+            this.member = member;
+            this.amount = amount;
+            this.impUid = impUid;
+        }
+
+        public Payment toEntity(final Member member, final Post post) {
             return Payment.builder()
                     .member(member)
                     .post(post)
                     .impUid(impUid)
                     .amount(amount)
                     .build();
-        }
-        @Builder
-        public DonateDTO(String member, Integer amount){
-            this.member = member;
-            this.amount = amount;
         }
 
     }

--- a/src/main/java/com/theocean/fundering/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/theocean/fundering/domain/payment/service/PaymentService.java
@@ -26,19 +26,19 @@ public class PaymentService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
 
-    public IamportResponse<Payment> verifyByImpUid(String impUid) throws IamportResponseException, IOException {
+    public IamportResponse<Payment> verifyByImpUid(final String impUid) throws IamportResponseException, IOException {
         return paymentConfig.iamportClient().paymentByImpUid(impUid);
     }
 
     @Transactional
-    public void donate(Long postId, String email, String impUid, PaymentRequest.DonateDTO donateDTO){
-        Member member = memberRepository.findByEmail(email).orElseThrow(
+    public void donate(final Long postId, final String email, final PaymentRequest.DonateDTO donateDTO) {
+        final Member member = memberRepository.findByEmail(email).orElseThrow(
                 () -> new Exception500("No matched member found")
         );
-        Post post = postRepository.findById(postId).orElseThrow(
+        final Post post = postRepository.findById(postId).orElseThrow(
                 () -> new Exception500("No matched post found")
         );
-        paymentRepository.save(donateDTO.toEntity(member, post, impUid));
+        paymentRepository.save(donateDTO.toEntity(member, post));
     }
 
 

--- a/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
+++ b/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
@@ -6,13 +6,22 @@ import com.theocean.fundering.domain.post.dto.PostRequest;
 import com.theocean.fundering.domain.post.dto.PostResponse;
 import com.theocean.fundering.domain.post.service.PostService;
 import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -23,66 +32,68 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping("/posts")
-    public ResponseEntity<?> findAll(@RequestParam(value = "postId", required = false) Long postId, Pageable pageable){
-        PageResponse<PostResponse.FindAllDTO> responseDTO = postService.findAll(postId, pageable);
-        return ResponseEntity.ok(ApiUtils.success(responseDTO));
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findAll(@RequestParam(value = "postId", required = false) final Long postId, final Pageable pageable) {
+        final PageResponse<PostResponse.FindAllDTO> responseDTO = postService.findAll(postId, pageable);
+        return ApiResult.success(responseDTO);
     }
 
     @GetMapping("/posts/{postId}")
-    public ResponseEntity<?> findByPostId(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long postId){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findByPostId(@AuthenticationPrincipal final CustomUserDetails userDetails, @PathVariable final Long postId) {
         String memberEmail = null;
-        if (userDetails != null)
+        if (null != userDetails)
             memberEmail = userDetails.getEmail();
-        PostResponse.FindByPostIdDTO responseDTO = postService.findByPostId(memberEmail, postId);
+        final PostResponse.FindByPostIdDTO responseDTO = postService.findByPostId(memberEmail, postId);
 
-        return ResponseEntity.ok(ApiUtils.success(responseDTO));
+        return ApiResult.success(responseDTO);
 
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/posts/{postId}/introduction")
-    public ResponseEntity<?> postIntroduction(@PathVariable Long postId){
-        String introduction = postService.getIntroduction(postId);
-        return ResponseEntity.ok(ApiUtils.success(introduction));
+    @GetMapping("/posts/{postId}/introduction")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> postIntroduction(@PathVariable final Long postId) {
+        final String introduction = postService.getIntroduction(postId);
+        return ApiResult.success(introduction);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/posts/write")
-    public ResponseEntity<?> writePost(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                       @ModelAttribute PostRequest.PostWriteDTO postWriteDTO,
-                                       @RequestPart(value = "thumbnail") MultipartFile thumbnail){
-        String writerEmail = userDetails.getEmail();
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> writePost(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                  @ModelAttribute final PostRequest.PostWriteDTO postWriteDTO,
+                                  @RequestPart("thumbnail") final MultipartFile thumbnail) {
+        final String writerEmail = userDetails.getEmail();
         postService.writePost(writerEmail, postWriteDTO, thumbnail);
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @PutMapping("/posts/{postId}/edit")
-    public ResponseEntity<?> editPost(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                      @PathVariable Long postId,
-                                      @ModelAttribute PostRequest.PostEditDTO postEditDTO,
-                                      @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail){
-        Long editedPost = postService.editPost(postId, postEditDTO, thumbnail);
-        return ResponseEntity.ok(ApiUtils.success(editedPost));
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> editPost(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                 @PathVariable final Long postId,
+                                 @ModelAttribute final PostRequest.PostEditDTO postEditDTO,
+                                 @RequestPart(value = "thumbnail", required = false) final MultipartFile thumbnail) {
+        final Long editedPost = postService.editPost(postId, postEditDTO, thumbnail);
+        return ApiResult.success(editedPost);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @DeleteMapping("/posts/{postId}/delete")
-    public ResponseEntity<?> deletePost(@PathVariable Long postId){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> deletePost(@PathVariable final Long postId) {
         postService.deletePost(postId);
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     @GetMapping("/posts/search")
-    public ResponseEntity<?> searchPost(@RequestParam(value = "postId", required = false) Long postId, @RequestParam(value = "keyword") String keyword, Pageable pageable){
-        var result = postService.searchPost(postId, keyword, pageable);
-        return ResponseEntity.ok(ApiUtils.success(result));
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> searchPost(@RequestParam(value = "postId", required = false) final Long postId, @RequestParam("keyword") final String keyword, final Pageable pageable) {
+        final var result = postService.searchPost(postId, keyword, pageable);
+        return ApiResult.success(result);
     }
 
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/uploadImg")
-    public ResponseEntity<?> uploadImage(@RequestPart(value = "image") MultipartFile img){
-        String result = postService.uploadImage(img);
-        return ResponseEntity.ok(ApiUtils.success(result));
-    }
+
 }

--- a/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
+++ b/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
@@ -2,7 +2,6 @@ package com.theocean.fundering.domain.post.controller;
 
 
 import com.theocean.fundering.domain.celebrity.dto.PageResponse;
-import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.post.dto.PostRequest;
 import com.theocean.fundering.domain.post.dto.PostResponse;
 import com.theocean.fundering.domain.post.service.PostService;
@@ -50,7 +49,7 @@ public class PostController {
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/posts/write")
     public ResponseEntity<?> writePost(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                       @RequestBody PostRequest.PostWriteDTO postWriteDTO,
+                                       @ModelAttribute PostRequest.PostWriteDTO postWriteDTO,
                                        @RequestPart(value = "thumbnail") MultipartFile thumbnail){
         String writerEmail = userDetails.getEmail();
         postService.writePost(writerEmail, postWriteDTO, thumbnail);
@@ -61,7 +60,7 @@ public class PostController {
     @PutMapping("/posts/{postId}/edit")
     public ResponseEntity<?> editPost(@AuthenticationPrincipal CustomUserDetails userDetails,
                                       @PathVariable Long postId,
-                                      @RequestBody PostRequest.PostEditDTO postEditDTO,
+                                      @ModelAttribute PostRequest.PostEditDTO postEditDTO,
                                       @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail){
         Long editedPost = postService.editPost(postId, postEditDTO, thumbnail);
         return ResponseEntity.ok(ApiUtils.success(editedPost));

--- a/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
+++ b/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
@@ -1,18 +1,27 @@
 package com.theocean.fundering.domain.post.controller;
 
 
-import com.theocean.fundering.global.dto.PageResponse;
 import com.theocean.fundering.domain.post.dto.PostRequest;
 import com.theocean.fundering.domain.post.dto.PostResponse;
 import com.theocean.fundering.domain.post.service.PostService;
+import com.theocean.fundering.global.dto.PageResponse;
 import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -23,66 +32,68 @@ public class PostController {
     private final PostService postService;
 
     @GetMapping("/posts")
-    public ResponseEntity<?> findAll(@RequestParam(value = "postId", required = false) Long postId, Pageable pageable){
-        PageResponse<PostResponse.FindAllDTO> responseDTO = postService.findAll(postId, pageable);
-        return ResponseEntity.ok(ApiUtils.success(responseDTO));
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findAll(@RequestParam(value = "postId", required = false) final Long postId, final Pageable pageable) {
+        final PageResponse<PostResponse.FindAllDTO> responseDTO = postService.findAll(postId, pageable);
+        return ApiResult.success(responseDTO);
     }
 
     @GetMapping("/posts/{postId}")
-    public ResponseEntity<?> findByPostId(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable Long postId){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> findByPostId(@AuthenticationPrincipal final CustomUserDetails userDetails, @PathVariable final Long postId) {
         String memberEmail = null;
-        if (userDetails != null)
+        if (null != userDetails)
             memberEmail = userDetails.getEmail();
-        PostResponse.FindByPostIdDTO responseDTO = postService.findByPostId(memberEmail, postId);
+        final PostResponse.FindByPostIdDTO responseDTO = postService.findByPostId(memberEmail, postId);
 
-        return ResponseEntity.ok(ApiUtils.success(responseDTO));
+        return ApiResult.success(responseDTO);
 
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/posts/{postId}/introduction")
-    public ResponseEntity<?> postIntroduction(@PathVariable Long postId){
-        String introduction = postService.getIntroduction(postId);
-        return ResponseEntity.ok(ApiUtils.success(introduction));
+    @GetMapping("/posts/{postId}/introduction")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> postIntroduction(@PathVariable final Long postId) {
+        final String introduction = postService.getIntroduction(postId);
+        return ApiResult.success(introduction);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @PostMapping("/posts/write")
-    public ResponseEntity<?> writePost(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                       @RequestBody PostRequest.PostWriteDTO postWriteDTO,
-                                       @RequestPart(value = "thumbnail") MultipartFile thumbnail){
-        String writerEmail = userDetails.getEmail();
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> writePost(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                  @ModelAttribute final PostRequest.PostWriteDTO postWriteDTO,
+                                  @RequestPart("thumbnail") final MultipartFile thumbnail) {
+        final String writerEmail = userDetails.getEmail();
         postService.writePost(writerEmail, postWriteDTO, thumbnail);
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @PutMapping("/posts/{postId}/edit")
-    public ResponseEntity<?> editPost(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                      @PathVariable Long postId,
-                                      @RequestBody PostRequest.PostEditDTO postEditDTO,
-                                      @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail){
-        Long editedPost = postService.editPost(postId, postEditDTO, thumbnail);
-        return ResponseEntity.ok(ApiUtils.success(editedPost));
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> editPost(@AuthenticationPrincipal final CustomUserDetails userDetails,
+                                 @PathVariable final Long postId,
+                                 @ModelAttribute final PostRequest.PostEditDTO postEditDTO,
+                                 @RequestPart(value = "thumbnail", required = false) final MultipartFile thumbnail) {
+        final Long editedPost = postService.editPost(postId, postEditDTO, thumbnail);
+        return ApiResult.success(editedPost);
     }
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @DeleteMapping("/posts/{postId}/delete")
-    public ResponseEntity<?> deletePost(@PathVariable Long postId){
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> deletePost(@PathVariable final Long postId) {
         postService.deletePost(postId);
-        return ResponseEntity.ok(ApiUtils.success(null));
+        return ApiResult.success(null);
     }
 
     @GetMapping("/posts/search")
-    public ResponseEntity<?> searchPost(@RequestParam(value = "postId", required = false) Long postId, @RequestParam(value = "keyword") String keyword, Pageable pageable){
-        var result = postService.searchPost(postId, keyword, pageable);
-        return ResponseEntity.ok(ApiUtils.success(result));
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> searchPost(@RequestParam(value = "postId", required = false) final Long postId, @RequestParam("keyword") final String keyword, final Pageable pageable) {
+        final var result = postService.searchPost(postId, keyword, pageable);
+        return ApiResult.success(result);
     }
 
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/uploadImg")
-    public ResponseEntity<?> uploadImage(@RequestPart(value = "image") MultipartFile img){
-        String result = postService.uploadImage(img);
-        return ResponseEntity.ok(ApiUtils.success(result));
-    }
+
 }

--- a/src/main/java/com/theocean/fundering/domain/post/domain/Post.java
+++ b/src/main/java/com/theocean/fundering/domain/post/domain/Post.java
@@ -3,9 +3,22 @@ package com.theocean.fundering.domain.post.domain;
 
 import com.theocean.fundering.domain.account.domain.Account;
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
-import com.theocean.fundering.global.utils.AuditingFields;
 import com.theocean.fundering.domain.member.domain.Member;
-import jakarta.persistence.*;
+import com.theocean.fundering.domain.post.domain.constant.PostStatus;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -21,7 +34,7 @@ import java.util.Objects;
 @Entity
 @Getter
 @EntityListeners(AuditingEntityListener.class)
-@Table(name="post")
+@Table(name = "post")
 public class Post extends AuditingFields {
 
     @Id
@@ -46,19 +59,24 @@ public class Post extends AuditingFields {
     @Column
     private String thumbnail;
 
-    @Column @Min(1000)
+    @Column
+    @Min(1000)
     private int targetPrice;
 
-    @Column @Min(0)
+    @Column
+    @Min(0)
     private int participants;
 
-    @Column @DateTimeFormat
+    @Column
+    @DateTimeFormat
     private LocalDateTime deadline;
 
+    @Enumerated(EnumType.STRING)
+    private PostStatus postStatus;
 
 
     @Builder
-    public Post(Long postId, Member writer, Celebrity celebrity, String title, String introduction, String thumbnail, int targetPrice, int participants, LocalDateTime deadline){
+    public Post(final Long postId, final Member writer, final Celebrity celebrity, final String title, final String introduction, final String thumbnail, final int targetPrice, final int participants, final LocalDateTime deadline, final PostStatus postStatus) {
         this.postId = postId;
         this.writer = writer;
         this.celebrity = celebrity;
@@ -68,12 +86,13 @@ public class Post extends AuditingFields {
         this.targetPrice = targetPrice;
         this.participants = participants;
         this.deadline = deadline;
+        this.postStatus = postStatus;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Post post)) return false;
+        if (!(o instanceof final Post post)) return false;
         return Objects.equals(postId, post.postId);
     }
 
@@ -82,9 +101,9 @@ public class Post extends AuditingFields {
         return Objects.hash(postId);
     }
 
-    public void update(String title, String content, String thumbnail, int targetPrice, LocalDateTime deadline, LocalDateTime modifiedAt){
+    public void update(final String title, final String content, final String thumbnail, final int targetPrice, final LocalDateTime deadline, final LocalDateTime modifiedAt) {
         this.title = title;
-        this.introduction = content;
+        introduction = content;
         this.thumbnail = thumbnail;
         this.targetPrice = targetPrice;
         this.deadline = deadline;

--- a/src/main/java/com/theocean/fundering/domain/post/domain/constant/PostStatus.java
+++ b/src/main/java/com/theocean/fundering/domain/post/domain/constant/PostStatus.java
@@ -1,0 +1,41 @@
+package com.theocean.fundering.domain.post.domain.constant;
+
+import jakarta.persistence.AttributeConverter;
+
+import java.util.Arrays;
+
+public enum PostStatus {
+    ONGOING("ONGOING"),
+    COMPLETE("COMPLETE"),
+    CLOSED("CLOSED");
+
+    private final String type;
+
+    PostStatus(final String type) {
+        this.type = type;
+    }
+
+    public static PostStatus fromString(final String type) {
+        return Arrays.stream(values())
+                .filter(postStatus -> postStatus.type.equals(type))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown type: %s".formatted(type)));
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public class PostStatusToStringConverter implements AttributeConverter<PostStatus, String> {
+
+        @Override
+        public String convertToDatabaseColumn(final PostStatus attribute) {
+            return attribute.getType();
+        }
+
+        @Override
+        public PostStatus convertToEntityAttribute(final String dbData) {
+            return fromString(dbData);
+        }
+    }
+}

--- a/src/main/java/com/theocean/fundering/domain/post/dto/PostRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/post/dto/PostRequest.java
@@ -4,7 +4,11 @@ package com.theocean.fundering.domain.post.dto;
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
 import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.post.domain.Post;
-import lombok.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
@@ -22,7 +26,18 @@ public class PostRequest {
         private LocalDateTime deadline;
         private LocalDateTime createdAt;
 
-        public Post toEntity(Member writer, Celebrity celebrity){
+        @Builder
+        public PostWriteDTO(final Long celebId, final String title, final String introduction, final String thumbnail, final int targetPrice, final LocalDateTime deadline) {
+            this.celebId = celebId;
+            this.title = title;
+            this.introduction = introduction;
+            this.thumbnail = thumbnail;
+            this.targetPrice = targetPrice;
+            this.deadline = deadline;
+            createdAt = LocalDateTime.now();
+        }
+
+        public Post toEntity(final Member writer, final Celebrity celebrity) {
             return Post.builder()
                     .writer(writer)
                     .celebrity(celebrity)
@@ -34,24 +49,13 @@ public class PostRequest {
                     .build();
         }
 
-        @Builder
-        public PostWriteDTO(Long celebId, String title, String introduction, String thumbnail, int targetPrice, LocalDateTime deadline){
-            this.celebId = celebId;
-            this.title = title;
-            this.introduction = introduction;
-            this.thumbnail = thumbnail;
-            this.targetPrice = targetPrice;
-            this.deadline = deadline;
-            this.createdAt = LocalDateTime.now();
-        }
-
     }
 
     @Getter
     @Setter
     @NoArgsConstructor
     @ToString
-    public static class PostEditDTO{
+    public static class PostEditDTO {
         private String title;
         private String introduction;
         private String thumbnail;
@@ -59,7 +63,17 @@ public class PostRequest {
         private LocalDateTime deadline;
         private LocalDateTime modifiedAt;
 
-        public Post toEntity(){
+        @Builder
+        public PostEditDTO(final String title, final String introduction, final String thumbnail, final int targetPrice, final LocalDateTime deadline) {
+            this.title = title;
+            this.introduction = introduction;
+            this.thumbnail = thumbnail;
+            this.targetPrice = targetPrice;
+            this.deadline = deadline;
+            modifiedAt = LocalDateTime.now();
+        }
+
+        public Post toEntity() {
             return Post.builder()
                     .title(title)
                     .introduction(introduction)
@@ -67,15 +81,6 @@ public class PostRequest {
                     .targetPrice(targetPrice)
                     .deadline(deadline)
                     .build();
-        }
-        @Builder
-        public PostEditDTO(String title, String introduction, String thumbnail, int targetPrice, LocalDateTime deadline){
-            this.title = title;
-            this.introduction = introduction;
-            this.thumbnail = thumbnail;
-            this.targetPrice = targetPrice;
-            this.deadline = deadline;
-            this.modifiedAt = LocalDateTime.now();
         }
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/post/dto/PostResponse.java
@@ -28,54 +28,55 @@ public class PostResponse {
         private int participant;
         private boolean eqWriter;
 
-        public FindByPostIdDTO( final Post post){
-                postId = post.getPostId();
-                writerId = post.getWriter().getUserId();
-                writer = post.getWriter().getNickname();
-                celebrity = post.getCelebrity().getCelebName();
-                celebImg = post.getCelebrity().getProfileImage();
-                title = post.getTitle();
-                content = post.getIntroduction();
-                thumbnail = post.getThumbnail();
-                targetPrice = post.getTargetPrice();
-                currentAmount = post.getAccount().getBalance();
-                deadline = post.getDeadline();
-                createdAt = post.getCreatedAt();
-                modifiedAt = post.getModifiedAt();
-                participant = post.getParticipants();
-                eqWriter = false;
-            }
+        public FindByPostIdDTO(final Post post) {
+            postId = post.getPostId();
+            writerId = post.getWriter().getUserId();
+            writer = post.getWriter().getNickname();
+            celebrity = post.getCelebrity().getCelebName();
+            celebImg = post.getCelebrity().getProfileImage();
+            title = post.getTitle();
+            content = post.getIntroduction();
+            thumbnail = post.getThumbnail();
+            targetPrice = post.getTargetPrice();
+            currentAmount = post.getAccount().getBalance();
+            deadline = post.getDeadline();
+            createdAt = post.getCreatedAt();
+            modifiedAt = post.getModifiedAt();
+            participant = post.getParticipants();
+            eqWriter = false;
         }
+    }
 
-        @Getter
-        @Setter
-        public static class FindAllDTO {
-            private Long postId;
-            private Long writerId;
-            private String writer;
-            private String celebrity;
-            private String celebImg;
-            private String title;
-            private String thumbnail;
-            private int targetPrice;
-            private int currentAmount;
-            private LocalDateTime deadline;
-            private LocalDateTime createdAt;
-            private LocalDateTime modifiedAt;
-        public FindAllDTO( final Post post){
-                    postId = post.getPostId();
-                    writerId = post.getWriter().getUserId();
-                    writer = post.getWriter().getNickname();
-                    celebrity = post.getCelebrity().getCelebName();
-                    celebImg = post.getCelebrity().getProfileImage();
-                    title = post.getTitle();
-                    thumbnail = post.getThumbnail();
-                    targetPrice = post.getTargetPrice();
-                    currentAmount = post.getAccount().getBalance();
-                    deadline = post.getDeadline();
-                    createdAt = post.getCreatedAt();
-                    modifiedAt = post.getModifiedAt();
-                }
-            }
+    @Getter
+    @Setter
+    public static class FindAllDTO {
+        private Long postId;
+        private Long writerId;
+        private String writer;
+        private String celebrity;
+        private String celebImg;
+        private String title;
+        private String thumbnail;
+        private int targetPrice;
+        private int currentAmount;
+        private LocalDateTime deadline;
+        private LocalDateTime createdAt;
+        private LocalDateTime modifiedAt;
 
+        public FindAllDTO(final Post post) {
+            postId = post.getPostId();
+            writerId = post.getWriter().getUserId();
+            writer = post.getWriter().getNickname();
+            celebrity = post.getCelebrity().getCelebName();
+            celebImg = post.getCelebrity().getProfileImage();
+            title = post.getTitle();
+            thumbnail = post.getThumbnail();
+            targetPrice = post.getTargetPrice();
+            currentAmount = post.getAccount().getBalance();
+            deadline = post.getDeadline();
+            createdAt = post.getCreatedAt();
+            modifiedAt = post.getModifiedAt();
         }
+    }
+
+}

--- a/src/main/java/com/theocean/fundering/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/post/dto/PostResponse.java
@@ -29,29 +29,29 @@ public class PostResponse {
         private boolean eqWriter;
 
 
-        public FindByPostIdDTO(Post post){
-            this.postId = post.getPostId();
-            this.writerId = post.getWriter().getUserId();
-            this.writer = post.getWriter().getNickname();
-            this.celebrity = post.getCelebrity().getCelebName();
-            this.celebImg = post.getCelebrity().getProfileImage();
-            this.title = post.getTitle();
-            this.content = post.getIntroduction();
-            this.thumbnail = post.getThumbnail();
-            this.targetPrice = post.getTargetPrice();
-            this.currentAmount = post.getAccount().getFundingAmount();
-            this.deadline = post.getDeadline();
-            this.createdAt = post.getCreatedAt();
-            this.modifiedAt = post.getModifiedAt();
-            this.participant = post.getParticipants();
-            this.eqWriter = false;
+        public FindByPostIdDTO(final Post post) {
+            postId = post.getPostId();
+            writerId = post.getWriter().getUserId();
+            writer = post.getWriter().getNickname();
+            celebrity = post.getCelebrity().getCelebName();
+            celebImg = post.getCelebrity().getProfileImage();
+            title = post.getTitle();
+            content = post.getIntroduction();
+            thumbnail = post.getThumbnail();
+            targetPrice = post.getTargetPrice();
+            currentAmount = post.getAccount().getFundingAmount();
+            deadline = post.getDeadline();
+            createdAt = post.getCreatedAt();
+            modifiedAt = post.getModifiedAt();
+            participant = post.getParticipants();
+            eqWriter = false;
         }
     }
 
 
     @Getter
     @Setter
-    public static class FindAllDTO{
+    public static class FindAllDTO {
         private Long postId;
         private Long writerId;
         private String writer;
@@ -65,19 +65,19 @@ public class PostResponse {
         private LocalDateTime createdAt;
         private LocalDateTime modifiedAt;
 
-        public FindAllDTO(Post post){
-            this.postId = post.getPostId();
-            this.writerId = post.getWriter().getUserId();
-            this.writer = post.getWriter().getNickname();
-            this.celebrity = post.getCelebrity().getCelebName();
-            this.celebImg = post.getCelebrity().getProfileImage();
-            this.title = post.getTitle();
-            this.thumbnail = post.getThumbnail();
-            this.targetPrice = post.getTargetPrice();
-            this.currentAmount = post.getAccount().getFundingAmount();
-            this.deadline = post.getDeadline();
-            this.createdAt = post.getCreatedAt();
-            this.modifiedAt = post.getModifiedAt();
+        public FindAllDTO(final Post post) {
+            postId = post.getPostId();
+            writerId = post.getWriter().getUserId();
+            writer = post.getWriter().getNickname();
+            celebrity = post.getCelebrity().getCelebName();
+            celebImg = post.getCelebrity().getProfileImage();
+            title = post.getTitle();
+            thumbnail = post.getThumbnail();
+            targetPrice = post.getTargetPrice();
+            currentAmount = post.getAccount().getFundingAmount();
+            deadline = post.getDeadline();
+            createdAt = post.getCreatedAt();
+            modifiedAt = post.getModifiedAt();
         }
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/post/dto/PostResponse.java
@@ -28,57 +28,54 @@ public class PostResponse {
         private int participant;
         private boolean eqWriter;
 
-
-        public FindByPostIdDTO(Post post){
-            this.postId = post.getPostId();
-            this.writerId = post.getWriter().getUserId();
-            this.writer = post.getWriter().getNickname();
-            this.celebrity = post.getCelebrity().getCelebName();
-            this.celebImg = post.getCelebrity().getProfileImage();
-            this.title = post.getTitle();
-            this.content = post.getIntroduction();
-            this.thumbnail = post.getThumbnail();
-            this.targetPrice = post.getTargetPrice();
-            this.currentAmount = post.getAccount().getBalance();
-            this.deadline = post.getDeadline();
-            this.createdAt = post.getCreatedAt();
-            this.modifiedAt = post.getModifiedAt();
-            this.participant = post.getParticipants();
-            this.eqWriter = false;
+        public FindByPostIdDTO( final Post post){
+                postId = post.getPostId();
+                writerId = post.getWriter().getUserId();
+                writer = post.getWriter().getNickname();
+                celebrity = post.getCelebrity().getCelebName();
+                celebImg = post.getCelebrity().getProfileImage();
+                title = post.getTitle();
+                content = post.getIntroduction();
+                thumbnail = post.getThumbnail();
+                targetPrice = post.getTargetPrice();
+                currentAmount = post.getAccount().getBalance();
+                deadline = post.getDeadline();
+                createdAt = post.getCreatedAt();
+                modifiedAt = post.getModifiedAt();
+                participant = post.getParticipants();
+                eqWriter = false;
+            }
         }
-    }
 
+        @Getter
+        @Setter
+        public static class FindAllDTO {
+            private Long postId;
+            private Long writerId;
+            private String writer;
+            private String celebrity;
+            private String celebImg;
+            private String title;
+            private String thumbnail;
+            private int targetPrice;
+            private int currentAmount;
+            private LocalDateTime deadline;
+            private LocalDateTime createdAt;
+            private LocalDateTime modifiedAt;
+        public FindAllDTO( final Post post){
+                    postId = post.getPostId();
+                    writerId = post.getWriter().getUserId();
+                    writer = post.getWriter().getNickname();
+                    celebrity = post.getCelebrity().getCelebName();
+                    celebImg = post.getCelebrity().getProfileImage();
+                    title = post.getTitle();
+                    thumbnail = post.getThumbnail();
+                    targetPrice = post.getTargetPrice();
+                    currentAmount = post.getAccount().getBalance();
+                    deadline = post.getDeadline();
+                    createdAt = post.getCreatedAt();
+                    modifiedAt = post.getModifiedAt();
+                }
+            }
 
-    @Getter
-    @Setter
-    public static class FindAllDTO{
-        private Long postId;
-        private Long writerId;
-        private String writer;
-        private String celebrity;
-        private String celebImg;
-        private String title;
-        private String thumbnail;
-        private int targetPrice;
-        private int currentAmount;
-        private LocalDateTime deadline;
-        private LocalDateTime createdAt;
-        private LocalDateTime modifiedAt;
-
-        public FindAllDTO(Post post){
-            this.postId = post.getPostId();
-            this.writerId = post.getWriter().getUserId();
-            this.writer = post.getWriter().getNickname();
-            this.celebrity = post.getCelebrity().getCelebName();
-            this.celebImg = post.getCelebrity().getProfileImage();
-            this.title = post.getTitle();
-            this.thumbnail = post.getThumbnail();
-            this.targetPrice = post.getTargetPrice();
-            this.currentAmount = post.getAccount().getBalance();
-            this.deadline = post.getDeadline();
-            this.createdAt = post.getCreatedAt();
-            this.modifiedAt = post.getModifiedAt();
         }
-    }
-
-}

--- a/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepository.java
@@ -5,11 +5,10 @@ import jakarta.annotation.Nullable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
-import java.util.List;
-
 public interface PostQuerydslRepository {
     Slice<PostResponse.FindAllDTO> findAll(@Nullable Long postId, Pageable pageable);
 
     Slice<PostResponse.FindAllDTO> findAllByWriterEmail(@Nullable Long postId, String email, Pageable pageable);
+
     Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable Long postId, String keyword, Pageable pageable);
 }

--- a/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepositoryImpl.java
@@ -13,23 +13,21 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 
-
-import static  com.theocean.fundering.domain.post.domain.QPost.post;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+
+import static com.theocean.fundering.domain.post.domain.QPost.post;
 
 @RequiredArgsConstructor
-public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
+public class PostQuerydslRepositoryImpl implements PostQuerydslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<PostResponse.FindAllDTO> findAll(@Nullable Long postId, Pageable pageable) {
-        OrderSpecifier[] orderSpecifiers = createOrderSpecifier(pageable.getSort());
+    public Slice<PostResponse.FindAllDTO> findAll(@Nullable final Long postId, final Pageable pageable) {
+        final OrderSpecifier[] orderSpecifiers = createOrderSpecifier(pageable.getSort());
 
-        List<PostResponse.FindAllDTO> contents =  jpaQueryFactory
+        final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -45,16 +43,13 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        boolean hasNext = false;
-        if(contents.size() > pageable.getPageSize()){
-            hasNext = true;
-        }
+        final boolean hasNext = contents.size() > pageable.getPageSize();
         return new SliceImpl<>(contents, pageable, hasNext);
     }
 
     @Override
-    public Slice<PostResponse.FindAllDTO> findAllByWriterEmail(@Nullable Long postId, String email, Pageable pageable) {
-        List<PostResponse.FindAllDTO> contents = jpaQueryFactory
+    public Slice<PostResponse.FindAllDTO> findAllByWriterEmail(@Nullable final Long postId, final String email, final Pageable pageable) {
+        final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -69,15 +64,13 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .orderBy(post.postId.desc())
                 .limit(pageable.getPageSize())
                 .fetch();
-        boolean hasNext = false;
-        if(contents.size() > pageable.getPageSize()){
-            hasNext = true;
-        }
+        final boolean hasNext = contents.size() > pageable.getPageSize();
         return new SliceImpl<>(contents, pageable, hasNext);
     }
+
     @Override
-    public Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable Long postId, String keyword, Pageable pageable){
-        List<PostResponse.FindAllDTO> contents = jpaQueryFactory
+    public Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable final Long postId, final String keyword, final Pageable pageable) {
+        final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -92,37 +85,35 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .orderBy(post.postId.desc())
                 .limit(pageable.getPageSize())
                 .fetch();
-        boolean hasNext = false;
-        if(contents.size() > pageable.getPageSize()){
-            hasNext = true;
-        }
+        final boolean hasNext = contents.size() > pageable.getPageSize();
         return new SliceImpl<>(contents, pageable, hasNext);
     }
 
-    private OrderSpecifier[] createOrderSpecifier(Sort sort){
-        List<OrderSpecifier> specifiers = new ArrayList<>();
+    private OrderSpecifier[] createOrderSpecifier(final Sort sort) {
+        final List<OrderSpecifier> specifiers = new ArrayList<>();
 
         /* 정렬 조건 추가 시 추가 작성
-        * */
-        if (sort.toString().equals("recent")) {
+         * */
+        if ("recent".equals(sort.toString())) {
             specifiers.add(new OrderSpecifier(Order.DESC, post.createdAt));
-        } else if(sort.toString().equals("deadline")) {
+        } else if ("deadline".equals(sort.toString())) {
             specifiers.add(new OrderSpecifier(Order.DESC, post.deadline));
-        } else if(sort.toString().equals("amount")){
+        } else if ("amount".equals(sort.toString())) {
             specifiers.add(new OrderSpecifier(Order.DESC, post.account.fundingAmount));
         }
         return specifiers.toArray(new OrderSpecifier[specifiers.size()]);
     }
 
-    private BooleanExpression ltPostId(@Nullable Long postId){
-        if (postId == null) return null;
+    private BooleanExpression ltPostId(@Nullable final Long postId) {
+        if (null == postId) return null;
         return post.postId.lt(postId);
     }
 
-    private BooleanExpression eqWriter(String email){
+    private BooleanExpression eqWriter(final String email) {
         return post.writer.email.eq(email);
     }
-    private BooleanExpression containKeyword(String keyword){
+
+    private BooleanExpression containKeyword(final String keyword) {
         return post.title.contains(keyword);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepositoryImpl.java
@@ -13,23 +13,21 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 
-
-import static  com.theocean.fundering.domain.post.domain.QPost.post;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+
+import static com.theocean.fundering.domain.post.domain.QPost.post;
 
 @RequiredArgsConstructor
-public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
+public class PostQuerydslRepositoryImpl implements PostQuerydslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<PostResponse.FindAllDTO> findAll(@Nullable Long postId, Pageable pageable) {
-        OrderSpecifier[] orderSpecifiers = createOrderSpecifier(pageable.getSort());
+    public Slice<PostResponse.FindAllDTO> findAll(@Nullable final Long postId, final Pageable pageable) {
+        final OrderSpecifier[] orderSpecifiers = createOrderSpecifier(pageable.getSort());
 
-        List<PostResponse.FindAllDTO> contents =  jpaQueryFactory
+        final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -45,16 +43,13 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        boolean hasNext = false;
-        if(contents.size() > pageable.getPageSize()){
-            hasNext = true;
-        }
+        final boolean hasNext = contents.size() > pageable.getPageSize();
         return new SliceImpl<>(contents, pageable, hasNext);
     }
 
     @Override
-    public Slice<PostResponse.FindAllDTO> findAllByWriterEmail(@Nullable Long postId, String email, Pageable pageable) {
-        List<PostResponse.FindAllDTO> contents = jpaQueryFactory
+    public Slice<PostResponse.FindAllDTO> findAllByWriterEmail(@Nullable final Long postId, final String email, final Pageable pageable) {
+        final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -69,15 +64,13 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .orderBy(post.postId.desc())
                 .limit(pageable.getPageSize())
                 .fetch();
-        boolean hasNext = false;
-        if(contents.size() > pageable.getPageSize()){
-            hasNext = true;
-        }
+        final boolean hasNext = contents.size() > pageable.getPageSize();
         return new SliceImpl<>(contents, pageable, hasNext);
     }
+
     @Override
-    public Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable Long postId, String keyword, Pageable pageable){
-        List<PostResponse.FindAllDTO> contents = jpaQueryFactory
+    public Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable final Long postId, final String keyword, final Pageable pageable) {
+        final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.title,
                         post.thumbnail,
@@ -92,37 +85,40 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository{
                 .orderBy(post.postId.desc())
                 .limit(pageable.getPageSize())
                 .fetch();
-        boolean hasNext = false;
-        if(contents.size() > pageable.getPageSize()){
-            hasNext = true;
-        }
+        final boolean hasNext = contents.size() > pageable.getPageSize();
         return new SliceImpl<>(contents, pageable, hasNext);
     }
 
-    private OrderSpecifier[] createOrderSpecifier(Sort sort){
-        List<OrderSpecifier> specifiers = new ArrayList<>();
+    private OrderSpecifier[] createOrderSpecifier(final Sort sort) {
+        final List<OrderSpecifier> specifiers = new ArrayList<>();
 
         /* 정렬 조건 추가 시 추가 작성
-        * */
-        if (sort.toString().equals("recent")) {
+         * */
+        if ("recent".equals(sort.toString())) {
             specifiers.add(new OrderSpecifier(Order.DESC, post.createdAt));
-        } else if(sort.toString().equals("deadline")) {
+        } else if ("deadline".equals(sort.toString())) {
             specifiers.add(new OrderSpecifier(Order.DESC, post.deadline));
-        } else if(sort.toString().equals("amount")){
+<<<<<<<HEAD
+        } else if ("amount".equals(sort.toString())) {
             specifiers.add(new OrderSpecifier(Order.DESC, post.account.balance));
+=======
+        } else if ("amount".equals(sort.toString())) {
+            specifiers.add(new OrderSpecifier(Order.DESC, post.account.fundingAmount));
+>>>>>>>feat
         }
         return specifiers.toArray(new OrderSpecifier[specifiers.size()]);
     }
 
-    private BooleanExpression ltPostId(@Nullable Long postId){
-        if (postId == null) return null;
+    private BooleanExpression ltPostId(@Nullable final Long postId) {
+        if (null == postId) return null;
         return post.postId.lt(postId);
     }
 
-    private BooleanExpression eqWriter(String email){
+    private BooleanExpression eqWriter(final String email) {
         return post.writer.email.eq(email);
     }
-    private BooleanExpression containKeyword(String keyword){
+
+    private BooleanExpression containKeyword(final String keyword) {
         return post.title.contains(keyword);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/PostRepository.java
@@ -4,10 +4,6 @@ package com.theocean.fundering.domain.post.repository;
 import com.theocean.fundering.domain.post.domain.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import javax.swing.text.html.Option;
-import java.util.List;
-import java.util.Optional;
-
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostQuerydslRepository {
 }

--- a/src/main/java/com/theocean/fundering/domain/post/service/PostService.java
+++ b/src/main/java/com/theocean/fundering/domain/post/service/PostService.java
@@ -30,64 +30,61 @@ public class PostService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void writePost(String email, PostRequest.PostWriteDTO dto, MultipartFile thumbnail){
+    public void writePost(final String email, final PostRequest.PostWriteDTO dto, final MultipartFile thumbnail) {
         dto.setThumbnail(awss3Uploader.uploadToS3(thumbnail));
-        Member writer =  memberRepository.findByEmail(email).orElseThrow(
+        final Member writer = memberRepository.findByEmail(email).orElseThrow(
                 () -> new Exception500("No matched member found")
         );
-        Celebrity celebrity = celebRepository.findById(dto.getCelebId()).orElseThrow(
+        final Celebrity celebrity = celebRepository.findById(dto.getCelebId()).orElseThrow(
                 () -> new Exception500("No matched celebrity found")
         );
         postRepository.save(dto.toEntity(writer, celebrity));
     }
 
-    public PostResponse.FindByPostIdDTO findByPostId(String email, Long postId){
-        Post postPS = postRepository.findById(postId).orElseThrow(
+    public PostResponse.FindByPostIdDTO findByPostId(final String email, final Long postId) {
+        final Post postPS = postRepository.findById(postId).orElseThrow(
                 () -> new Exception500("No matched post found")
         );
-        PostResponse.FindByPostIdDTO result = new PostResponse.FindByPostIdDTO(postPS);
+        final PostResponse.FindByPostIdDTO result = new PostResponse.FindByPostIdDTO(postPS);
         if (postPS.getWriter().getEmail().equals(email))
             result.setEqWriter(true);
         return result;
     }
 
-    public PageResponse<PostResponse.FindAllDTO> findAll(@Nullable Long postId, Pageable pageable){
-        var postList = postRepository.findAll(postId, pageable);
+    public PageResponse<PostResponse.FindAllDTO> findAll(@Nullable final Long postId, final Pageable pageable) {
+        final var postList = postRepository.findAll(postId, pageable);
         return new PageResponse<>(postList);
 
     }
 
-    public PageResponse<PostResponse.FindAllDTO> findAllByWriterId(@Nullable Long postId, String email, Pageable pageable){
-        var postList = postRepository.findAllByWriterEmail(postId, email, pageable);
+    public PageResponse<PostResponse.FindAllDTO> findAllByWriterId(@Nullable final Long postId, final String email, final Pageable pageable) {
+        final var postList = postRepository.findAllByWriterEmail(postId, email, pageable);
         return new PageResponse<>(postList);
     }
 
     @Transactional
-    public Long editPost(Long postId, PostRequest.PostEditDTO dto, @Nullable MultipartFile thumbnail){
-        if (thumbnail != null)
+    public Long editPost(final Long postId, final PostRequest.PostEditDTO dto, @Nullable final MultipartFile thumbnail) {
+        if (null != thumbnail)
             dto.setThumbnail(awss3Uploader.uploadToS3(thumbnail));
-        Post postPS = postRepository.findById(postId).orElseThrow(
+        final Post postPS = postRepository.findById(postId).orElseThrow(
                 () -> new Exception500("No matched post found")
         );
         postPS.update(dto.getTitle(), dto.getIntroduction(), dto.getThumbnail(), dto.getTargetPrice(), dto.getDeadline(), dto.getModifiedAt());
         return postId;
     }
 
-    public void deletePost(Long postId){
+    public void deletePost(final Long postId) {
         postRepository.deleteById(postId);
     }
 
-    public PageResponse<PostResponse.FindAllDTO> searchPost(@Nullable Long postId, String keyword, Pageable pageable){
-        var postList = postRepository.findAllByKeyword(postId, keyword, pageable);
+    public PageResponse<PostResponse.FindAllDTO> searchPost(@Nullable final Long postId, final String keyword, final Pageable pageable) {
+        final var postList = postRepository.findAllByKeyword(postId, keyword, pageable);
         return new PageResponse<>(postList);
 
     }
 
-    public String uploadImage(MultipartFile img){
-        return awss3Uploader.uploadToS3(img);
-    }
 
-    public String getIntroduction(Long postId){
+    public String getIntroduction(final Long postId) {
         return postRepository.findById(postId).orElseThrow(
                 () -> new Exception500("No mathced post found")
         ).getIntroduction();

--- a/src/main/java/com/theocean/fundering/domain/post/service/PostService.java
+++ b/src/main/java/com/theocean/fundering/domain/post/service/PostService.java
@@ -2,7 +2,6 @@ package com.theocean.fundering.domain.post.service;
 
 
 import com.theocean.fundering.domain.celebrity.domain.Celebrity;
-import com.theocean.fundering.global.dto.PageResponse;
 import com.theocean.fundering.domain.celebrity.repository.CelebRepository;
 import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
@@ -10,6 +9,7 @@ import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.domain.post.dto.PostRequest;
 import com.theocean.fundering.domain.post.dto.PostResponse;
 import com.theocean.fundering.domain.post.repository.PostRepository;
+import com.theocean.fundering.global.dto.PageResponse;
 import com.theocean.fundering.global.errors.exception.Exception500;
 import com.theocean.fundering.global.utils.AWSS3Uploader;
 import jakarta.annotation.Nullable;
@@ -30,64 +30,61 @@ public class PostService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void writePost(String email, PostRequest.PostWriteDTO dto, MultipartFile thumbnail){
+    public void writePost(final String email, final PostRequest.PostWriteDTO dto, final MultipartFile thumbnail) {
         dto.setThumbnail(awss3Uploader.uploadToS3(thumbnail));
-        Member writer =  memberRepository.findByEmail(email).orElseThrow(
+        final Member writer = memberRepository.findByEmail(email).orElseThrow(
                 () -> new Exception500("No matched member found")
         );
-        Celebrity celebrity = celebRepository.findById(dto.getCelebId()).orElseThrow(
+        final Celebrity celebrity = celebRepository.findById(dto.getCelebId()).orElseThrow(
                 () -> new Exception500("No matched celebrity found")
         );
         postRepository.save(dto.toEntity(writer, celebrity));
     }
 
-    public PostResponse.FindByPostIdDTO findByPostId(String email, Long postId){
-        Post postPS = postRepository.findById(postId).orElseThrow(
+    public PostResponse.FindByPostIdDTO findByPostId(final String email, final Long postId) {
+        final Post postPS = postRepository.findById(postId).orElseThrow(
                 () -> new Exception500("No matched post found")
         );
-        PostResponse.FindByPostIdDTO result = new PostResponse.FindByPostIdDTO(postPS);
+        final PostResponse.FindByPostIdDTO result = new PostResponse.FindByPostIdDTO(postPS);
         if (postPS.getWriter().getEmail().equals(email))
             result.setEqWriter(true);
         return result;
     }
 
-    public PageResponse<PostResponse.FindAllDTO> findAll(@Nullable Long postId, Pageable pageable){
-        var postList = postRepository.findAll(postId, pageable);
+    public PageResponse<PostResponse.FindAllDTO> findAll(@Nullable final Long postId, final Pageable pageable) {
+        final var postList = postRepository.findAll(postId, pageable);
         return new PageResponse<>(postList);
 
     }
 
-    public PageResponse<PostResponse.FindAllDTO> findAllByWriterId(@Nullable Long postId, String email, Pageable pageable){
-        var postList = postRepository.findAllByWriterEmail(postId, email, pageable);
+    public PageResponse<PostResponse.FindAllDTO> findAllByWriterId(@Nullable final Long postId, final String email, final Pageable pageable) {
+        final var postList = postRepository.findAllByWriterEmail(postId, email, pageable);
         return new PageResponse<>(postList);
     }
 
     @Transactional
-    public Long editPost(Long postId, PostRequest.PostEditDTO dto, @Nullable MultipartFile thumbnail){
-        if (thumbnail != null)
+    public Long editPost(final Long postId, final PostRequest.PostEditDTO dto, @Nullable final MultipartFile thumbnail) {
+        if (null != thumbnail)
             dto.setThumbnail(awss3Uploader.uploadToS3(thumbnail));
-        Post postPS = postRepository.findById(postId).orElseThrow(
+        final Post postPS = postRepository.findById(postId).orElseThrow(
                 () -> new Exception500("No matched post found")
         );
         postPS.update(dto.getTitle(), dto.getIntroduction(), dto.getThumbnail(), dto.getTargetPrice(), dto.getDeadline(), dto.getModifiedAt());
         return postId;
     }
 
-    public void deletePost(Long postId){
+    public void deletePost(final Long postId) {
         postRepository.deleteById(postId);
     }
 
-    public PageResponse<PostResponse.FindAllDTO> searchPost(@Nullable Long postId, String keyword, Pageable pageable){
-        var postList = postRepository.findAllByKeyword(postId, keyword, pageable);
+    public PageResponse<PostResponse.FindAllDTO> searchPost(@Nullable final Long postId, final String keyword, final Pageable pageable) {
+        final var postList = postRepository.findAllByKeyword(postId, keyword, pageable);
         return new PageResponse<>(postList);
 
     }
 
-    public String uploadImage(MultipartFile img){
-        return awss3Uploader.uploadToS3(img);
-    }
 
-    public String getIntroduction(Long postId){
+    public String getIntroduction(final Long postId) {
         return postRepository.findById(postId).orElseThrow(
                 () -> new Exception500("No mathced post found")
         ).getIntroduction();

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/controller/WithdrawalController.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/controller/WithdrawalController.java
@@ -38,7 +38,7 @@ public class WithdrawalController {
 
     // (기능) 출금내역 조회
     @GetMapping("/posts/{postId}/withdrawals")
-    public ResponseEntity<?> readWithdrawals(@PathVariable final long postId, @PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<?> readWithdrawals(@PathVariable final long postId, @PageableDefault(size = 10) final Pageable pageable) {
 
         final WithdrawalResponse.FindAllDTO response = withdrawalService.getWithdrawals(postId, pageable);
 

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
@@ -1,7 +1,5 @@
 package com.theocean.fundering.domain.withdrawal.domain;
 
-import com.theocean.fundering.domain.member.domain.Member;
-import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.global.utils.AuditingFields;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -63,67 +61,36 @@ public class Withdrawal extends AuditingFields {
 
     // 생성자
     @Builder
-<<<<<<<HEAD
-
     public Withdrawal(final Long applicantId, final Long postId, final String usage, final String depositAccount, final int withdrawalAmount) {
         this.applicantId = applicantId;
         this.postId = postId;
-=======
-    public Withdrawal( final Member member, final Post post, final String usage, final String depositAccount,
-        final Integer withdrawalAmount, final Boolean isApproved){
-            this.member = member;
-            this.post = post;
->>>>>>>feat
-            this.usage = usage;
-            this.depositAccount = depositAccount;
-            this.withdrawalAmount = withdrawalAmount;
-            isApproved = true;
-        }
+        this.usage = usage;
+        this.depositAccount = depositAccount;
+        this.withdrawalAmount = withdrawalAmount;
+        isApproved = true;
+    }
 
-<<<<<<<HEAD
-        public long getDepositTime () {
-            return modifiedAt.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
-        }
+    public long getDepositTime() {
+        return modifiedAt.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
+    }
 
-        public void approveWithdrawal () {
-            isApproved = true;
-        }
+    public void approveWithdrawal() {
+        isApproved = true;
+    }
 
-        public void updateBalance ( int balance){
-            this.balance = balance;
-=======
-            // Setter Methods
-            public void updateUsage ( final String usage){
-                this.usage = usage;
-            }
+    public void updateBalance(final int balance) {
+        this.balance = balance;
+    }
 
-            public void updateDepositAccount ( final String depositAccount){
-                this.depositAccount = depositAccount;
-            }
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof final Withdrawal withdrawal)) return false;
+        return Objects.equals(withdrawalId, withdrawal.withdrawalId);
+    }
 
-            public void updateWithdrawalAmount ( final Integer withdrawalAmount){
-                this.withdrawalAmount = withdrawalAmount;
-            }
-
-            public void updateIsApproved ( final boolean isApproved){
-                this.isApproved = isApproved;
->>>>>>>feat
-            }
-
-            @Override
-            public boolean equals ( final Object o){
-                if (this == o) return true;
-<<<<<<<HEAD
-                if (!(o instanceof final Withdrawal withdrawal)) return false;
-                return Objects.equals(withdrawalId, withdrawal.withdrawalId);
-=======
-                if (!(o instanceof final Withdrawal that)) return false;
-                return Objects.equals(withdrawal_id, that.withdrawal_id);
->>>>>>>feat
-            }
-
-            @Override
-            public int hashCode () {
-                return Objects.hash(withdrawalId);
-            }
-        }
+    @Override
+    public int hashCode() {
+        return Objects.hash(withdrawalId);
+    }
+}

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
@@ -1,5 +1,7 @@
 package com.theocean.fundering.domain.withdrawal.domain;
 
+import com.theocean.fundering.domain.member.domain.Member;
+import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.global.utils.AuditingFields;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,11 +15,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZoneId;
 import java.util.Objects;
 
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+>>>>>>>feat
 
 @Entity
 @Table(name = "Withdrawal")
@@ -45,7 +48,7 @@ public class Withdrawal extends AuditingFields {
     private String depositAccount;
 
     // 출금액
-    @Min(value = 0)
+    @Min(0)
     @Column(nullable = false)
     private int withdrawalAmount;
 
@@ -54,42 +57,73 @@ public class Withdrawal extends AuditingFields {
     private Boolean isApproved;
 
     // 출금시 계좌 잔액
-    @Min(value = 0)
+    @Min(0)
     @Column
     private Integer balance;
 
     // 생성자
     @Builder
+<<<<<<<HEAD
+
     public Withdrawal(final Long applicantId, final Long postId, final String usage, final String depositAccount, final int withdrawalAmount) {
         this.applicantId = applicantId;
         this.postId = postId;
-        this.usage = usage;
-        this.depositAccount = depositAccount;
-        this.withdrawalAmount = withdrawalAmount;
-        isApproved = true;
-    }
+=======
+    public Withdrawal( final Member member, final Post post, final String usage, final String depositAccount,
+        final Integer withdrawalAmount, final Boolean isApproved){
+            this.member = member;
+            this.post = post;
+>>>>>>>feat
+            this.usage = usage;
+            this.depositAccount = depositAccount;
+            this.withdrawalAmount = withdrawalAmount;
+            isApproved = true;
+        }
 
-    public long getDepositTime() {
-        return modifiedAt.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
-    }
+<<<<<<<HEAD
+        public long getDepositTime () {
+            return modifiedAt.atZone(ZoneId.systemDefault()).toInstant().getEpochSecond();
+        }
 
-    public void approveWithdrawal() {
-        isApproved = true;
-    }
+        public void approveWithdrawal () {
+            isApproved = true;
+        }
 
-    public void updateBalance(int balance){
-        this.balance = balance;
-    }
+        public void updateBalance ( int balance){
+            this.balance = balance;
+=======
+            // Setter Methods
+            public void updateUsage ( final String usage){
+                this.usage = usage;
+            }
 
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof final Withdrawal withdrawal)) return false;
-        return Objects.equals(withdrawalId, withdrawal.withdrawalId);
-    }
+            public void updateDepositAccount ( final String depositAccount){
+                this.depositAccount = depositAccount;
+            }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(withdrawalId);
-    }
-}
+            public void updateWithdrawalAmount ( final Integer withdrawalAmount){
+                this.withdrawalAmount = withdrawalAmount;
+            }
+
+            public void updateIsApproved ( final boolean isApproved){
+                this.isApproved = isApproved;
+>>>>>>>feat
+            }
+
+            @Override
+            public boolean equals ( final Object o){
+                if (this == o) return true;
+<<<<<<<HEAD
+                if (!(o instanceof final Withdrawal withdrawal)) return false;
+                return Objects.equals(withdrawalId, withdrawal.withdrawalId);
+=======
+                if (!(o instanceof final Withdrawal that)) return false;
+                return Objects.equals(withdrawal_id, that.withdrawal_id);
+>>>>>>>feat
+            }
+
+            @Override
+            public int hashCode () {
+                return Objects.hash(withdrawalId);
+            }
+        }

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
@@ -1,19 +1,26 @@
 package com.theocean.fundering.domain.withdrawal.domain;
 
-import com.theocean.fundering.global.utils.AuditingFields;
-import com.theocean.fundering.domain.post.domain.Post;
 import com.theocean.fundering.domain.member.domain.Member;
+import com.theocean.fundering.domain.post.domain.Post;
+import com.theocean.fundering.global.utils.AuditingFields;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import jakarta.persistence.*;
-import java.time.LocalDateTime;
-import java.util.Objects;
-
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "Withdrawal")
@@ -56,8 +63,8 @@ public class Withdrawal extends AuditingFields {
 
     // 생성자
     @Builder
-    public Withdrawal(Member member, Post post, String usage, String depositAccount,
-                      Integer withdrawalAmount, Boolean isApproved) {
+    public Withdrawal(final Member member, final Post post, final String usage, final String depositAccount,
+                      final Integer withdrawalAmount, final Boolean isApproved) {
         this.member = member;
         this.post = post;
         this.usage = usage;
@@ -67,26 +74,26 @@ public class Withdrawal extends AuditingFields {
     }
 
     // Setter Methods
-    public void updateUsage(String usage) {
+    public void updateUsage(final String usage) {
         this.usage = usage;
     }
 
-    public void updateDepositAccount(String depositAccount) {
+    public void updateDepositAccount(final String depositAccount) {
         this.depositAccount = depositAccount;
     }
 
-    public void updateWithdrawalAmount(Integer withdrawalAmount) {
+    public void updateWithdrawalAmount(final Integer withdrawalAmount) {
         this.withdrawalAmount = withdrawalAmount;
     }
 
-    public void updateIsApproved(boolean isApproved) {
+    public void updateIsApproved(final boolean isApproved) {
         this.isApproved = isApproved;
     }
 
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(final Object o) {
         if (this == o) return true;
-        if (!(o instanceof Withdrawal that)) return false;
+        if (!(o instanceof final Withdrawal that)) return false;
         return Objects.equals(withdrawal_id, that.withdrawal_id);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
@@ -18,7 +18,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.ZoneId;
 import java.util.Objects;
 
->>>>>>>feat
 
 @Entity
 @Table(name = "Withdrawal")

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/dto/WithdrawalRequest.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/dto/WithdrawalRequest.java
@@ -17,7 +17,7 @@ public class WithdrawalRequest {
         @Min(message = "신청 금액은 최소 10000원 이상 입니다.", value = 10000)
         private final int amount;
 
-        public SaveDTO(String usage, String depositAccount, int amount) {
+        public SaveDTO(final String usage, final String depositAccount, final int amount) {
             this.usage = usage;
             this.depositAccount = depositAccount;
             this.amount = amount;

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/dto/WithdrawalResponse.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/dto/WithdrawalResponse.java
@@ -1,6 +1,5 @@
 package com.theocean.fundering.domain.withdrawal.dto;
 
-import com.theocean.fundering.domain.comment.domain.Comment;
 import com.theocean.fundering.domain.withdrawal.domain.Withdrawal;
 import lombok.Getter;
 
@@ -38,12 +37,12 @@ public class WithdrawalResponse {
 
 
         WithdrawalDTO(final Withdrawal withdrawal, final String evidenceURL) {
-            this.withdrawalId = withdrawal.getWithdrawalId();
-            this.usage = withdrawal.getUsage();
-            this.depositAmount = withdrawal.getWithdrawalAmount();
-            this.balance = withdrawal.getBalance();
-            this.evidence = evidenceURL;
-            this.depositTime = withdrawal.getDepositTime();
+            withdrawalId = withdrawal.getWithdrawalId();
+            usage = withdrawal.getUsage();
+            depositAmount = withdrawal.getWithdrawalAmount();
+            balance = withdrawal.getBalance();
+            evidence = evidenceURL;
+            depositTime = withdrawal.getDepositTime();
         }
 
         public static WithdrawalDTO fromEntity(final Withdrawal withdrawal, final String evidenceURL) {

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/service/WithdrawalService.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/service/WithdrawalService.java
@@ -2,11 +2,8 @@ package com.theocean.fundering.domain.withdrawal.service;
 
 import com.theocean.fundering.domain.account.domain.Account;
 import com.theocean.fundering.domain.account.repository.AccountRepository;
-import com.theocean.fundering.domain.comment.domain.Comment;
-import com.theocean.fundering.domain.comment.dto.CommentResponse;
 import com.theocean.fundering.domain.evidence.domain.Evidence;
 import com.theocean.fundering.domain.evidence.repository.EvidenceRepository;
-import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.withdrawal.domain.Withdrawal;
 import com.theocean.fundering.domain.withdrawal.dto.WithdrawalRequest;
 import com.theocean.fundering.domain.withdrawal.dto.WithdrawalResponse;
@@ -15,7 +12,6 @@ import com.theocean.fundering.global.errors.exception.Exception404;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -46,18 +42,18 @@ public class WithdrawalService {
         withdrawalRepository.save(withdrawal);
     }
 
-    public WithdrawalResponse.FindAllDTO getWithdrawals(final Long postId, Pageable pageable){
-        Account account = accountRepository.findByPostId(postId)
+    public WithdrawalResponse.FindAllDTO getWithdrawals(final Long postId, final Pageable pageable) {
+        final Account account = accountRepository.findByPostId(postId)
                 .orElseThrow(() -> new Exception404("계좌가 존재하지 않습니다."));
-        int currentBalance = account.getBalance();
+        final int currentBalance = account.getBalance();
 
-        Page<Withdrawal> withdrawalPage = withdrawalRepository.getWithdrawalPage(postId, pageable);
-        List<Withdrawal> withdrawals = withdrawalPage.getContent();
+        final Page<Withdrawal> withdrawalPage = withdrawalRepository.getWithdrawalPage(postId, pageable);
+        final List<Withdrawal> withdrawals = withdrawalPage.getContent();
 
         final List<WithdrawalResponse.WithdrawalDTO> withdrawalDTOs = convertToWithdrawalDTOs(withdrawals);
 
-        int currentPage = pageable.getPageNumber();
-        boolean isLastPage = withdrawalPage.isLast();
+        final int currentPage = pageable.getPageNumber();
+        final boolean isLastPage = withdrawalPage.isLast();
 
         return new WithdrawalResponse.FindAllDTO(account.getBalance(), withdrawalDTOs, currentPage, isLastPage);
     }
@@ -68,7 +64,7 @@ public class WithdrawalService {
     }
 
     private WithdrawalResponse.WithdrawalDTO createWithdrawalDTO(final Withdrawal withdrawal) {
-        Optional<Evidence> evidence = evidenceRepository.findByWithdrawalId(withdrawal.getWithdrawalId());
+        final Optional<Evidence> evidence = evidenceRepository.findByWithdrawalId(withdrawal.getWithdrawalId());
         String evidenceURL = null;
         if (evidence.isPresent()) evidenceURL = evidence.get().getUrl();
 

--- a/src/main/java/com/theocean/fundering/global/config/AWSS3Config.java
+++ b/src/main/java/com/theocean/fundering/global/config/AWSS3Config.java
@@ -1,7 +1,6 @@
 package com.theocean.fundering.global.config;
 
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
@@ -12,7 +11,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 public class AWSS3Config {
 
     @Bean
-    public S3Client s3Client(){
+    public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.AP_NORTHEAST_2)
                 .credentialsProvider(ProfileCredentialsProvider.create())

--- a/src/main/java/com/theocean/fundering/global/config/CacheConfig.java
+++ b/src/main/java/com/theocean/fundering/global/config/CacheConfig.java
@@ -14,7 +14,7 @@ public class CacheConfig {
 
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        final CaffeineCacheManager cacheManager = new CaffeineCacheManager();
         cacheManager.setCaffeine(Caffeine.newBuilder().maximumSize(100)); // 최대 캐시 크기 설정
         return cacheManager;
     }

--- a/src/main/java/com/theocean/fundering/global/config/PaymentConfig.java
+++ b/src/main/java/com/theocean/fundering/global/config/PaymentConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class PaymentConfig {
 
     @Bean
-    public IamportClient iamportClient(){
-        return new IamportClient("","");
+    public IamportClient iamportClient() {
+        return new IamportClient("", "");
     }
 }

--- a/src/main/java/com/theocean/fundering/global/config/QuerydslConfig.java
+++ b/src/main/java/com/theocean/fundering/global/config/QuerydslConfig.java
@@ -1,11 +1,10 @@
 package com.theocean.fundering.global.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class QuerydslConfig {

--- a/src/main/java/com/theocean/fundering/global/config/security/SpringSecurityConfig.java
+++ b/src/main/java/com/theocean/fundering/global/config/security/SpringSecurityConfig.java
@@ -2,7 +2,6 @@ package com.theocean.fundering.global.config.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
-import com.theocean.fundering.global.errors.exception.Exception403;
 import com.theocean.fundering.global.jwt.JwtProvider;
 import com.theocean.fundering.global.jwt.filter.JwtAuthenticationFilter;
 import com.theocean.fundering.global.jwt.handler.LoginFailureHandler;
@@ -51,15 +50,6 @@ public class SpringSecurityConfig {
         return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
-    public class CustomSecurityFilterManager extends AbstractHttpConfigurer<CustomSecurityFilterManager, HttpSecurity> {
-        @Override
-        public void configure(final HttpSecurity builder) throws Exception {
-            final AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
-            builder.addFilter(new JwtAuthenticationFilter(authenticationManager, memberRepository, jwtProvider));
-            super.configure(builder);
-        }
-    }
-
     @Bean
     public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
         //csrf disable
@@ -105,6 +95,7 @@ public class SpringSecurityConfig {
         );
         return http.build();
     }
+
     private CorsConfigurationSource configurationSource() {
         final CorsConfiguration configuration = new CorsConfiguration();
         configuration.addAllowedHeader("*");
@@ -148,5 +139,14 @@ public class SpringSecurityConfig {
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationProcessingFilter() {
         return new JwtAuthenticationFilter(authenticationManager(), memberRepository, jwtProvider);
+    }
+
+    public class CustomSecurityFilterManager extends AbstractHttpConfigurer<CustomSecurityFilterManager, HttpSecurity> {
+        @Override
+        public void configure(final HttpSecurity builder) throws Exception {
+            final AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
+            builder.addFilter(new JwtAuthenticationFilter(authenticationManager, memberRepository, jwtProvider));
+            super.configure(builder);
+        }
     }
 }

--- a/src/main/java/com/theocean/fundering/global/dto/PageResponse.java
+++ b/src/main/java/com/theocean/fundering/global/dto/PageResponse.java
@@ -1,15 +1,9 @@
 package com.theocean.fundering.global.dto;
 
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.Sort;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 public class PageResponse<T> {
@@ -17,9 +11,17 @@ public class PageResponse<T> {
     private final int currentPage;
     private final boolean isLastPage;
 
+<<<<<<<HEAD:src/main/java/com/theocean/fundering/global/dto/PageResponse.java
+
     public PageResponse(Slice<T> sliceContent) {
-        this.content = sliceContent.getContent();
-        this.currentPage = sliceContent.getNumber() + 1;
-        this.isLastPage = sliceContent.isLast();
+        content = sliceContent.getContent();
+        currentPage = sliceContent.getNumber() + 1;
+        isLastPage = sliceContent.isLast();
+=======
+    public PageResponse( final Slice<T> sliceContent){
+            content = sliceContent.getContent();
+            currentPage = sliceContent.getNumber() + 1;
+            isLast = sliceContent.isLast();
+>>>>>>>src / main / java / com / theocean / fundering / domain / celebrity / dto / PageResponse.java
+        }
     }
-}

--- a/src/main/java/com/theocean/fundering/global/dto/PageResponse.java
+++ b/src/main/java/com/theocean/fundering/global/dto/PageResponse.java
@@ -11,17 +11,10 @@ public class PageResponse<T> {
     private final int currentPage;
     private final boolean isLastPage;
 
-<<<<<<<HEAD:src/main/java/com/theocean/fundering/global/dto/PageResponse.java
-
-    public PageResponse(Slice<T> sliceContent) {
+    public PageResponse(final Slice<T> sliceContent) {
         content = sliceContent.getContent();
         currentPage = sliceContent.getNumber() + 1;
         isLastPage = sliceContent.isLast();
-=======
-    public PageResponse( final Slice<T> sliceContent){
-            content = sliceContent.getContent();
-            currentPage = sliceContent.getNumber() + 1;
-            isLast = sliceContent.isLast();
->>>>>>>src / main / java / com / theocean / fundering / domain / celebrity / dto / PageResponse.java
-        }
+
     }
+}

--- a/src/main/java/com/theocean/fundering/global/errors/GlobalExceptionHandler.java
+++ b/src/main/java/com/theocean/fundering/global/errors/GlobalExceptionHandler.java
@@ -1,19 +1,21 @@
 package com.theocean.fundering.global.errors;
 
-import com.theocean.fundering.global.errors.exception.*;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.errors.exception.Exception400;
+import com.theocean.fundering.global.errors.exception.Exception401;
+import com.theocean.fundering.global.errors.exception.Exception403;
+import com.theocean.fundering.global.errors.exception.Exception404;
+import com.theocean.fundering.global.errors.exception.Exception500;
+import com.theocean.fundering.global.utils.ApiResult;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
-import org.springframework.web.bind.annotation.ExceptionHandler;
-
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
-
-import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.List;
 
@@ -21,61 +23,61 @@ import java.util.List;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception400.class)
-    public ResponseEntity<?> badRequest(Exception400 e) {
+    public ResponseEntity<?> badRequest(final Exception400 e) {
         return new ResponseEntity<>(e.body(), e.status());
     }
 
     @ExceptionHandler(Exception401.class)
-    public ResponseEntity<?> unAuthorized(Exception401 e) {
+    public ResponseEntity<?> unAuthorized(final Exception401 e) {
         return new ResponseEntity<>(e.body(), e.status());
     }
 
     @ExceptionHandler(Exception403.class)
-    public ResponseEntity<?> forbidden(Exception403 e) {
+    public ResponseEntity<?> forbidden(final Exception403 e) {
         return new ResponseEntity<>(e.body(), e.status());
     }
 
     @ExceptionHandler(Exception404.class)
-    public ResponseEntity<?> notFound(Exception404 e) {
+    public ResponseEntity<?> notFound(final Exception404 e) {
         return new ResponseEntity<>(e.body(), e.status());
     }
 
     @ExceptionHandler(Exception500.class)
-    public ResponseEntity<?> serverError(Exception500 e) {
+    public ResponseEntity<?> serverError(final Exception500 e) {
         return new ResponseEntity<>(e.body(), e.status());
     }
 
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<?> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        BindingResult bindingResult = ex.getBindingResult();
-        List<FieldError> fieldErrors = bindingResult.getFieldErrors();
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResult<?> handleValidationExceptions(final MethodArgumentNotValidException ex) {
+        final BindingResult bindingResult = ex.getBindingResult();
+        final List<FieldError> fieldErrors = bindingResult.getFieldErrors();
 
         // 필드 에러들 중에서 첫 번째 에러의 기본 메시지만 가져옵니다.
-        String errorMessage = fieldErrors.stream()
+        final String errorMessage = fieldErrors.stream()
                 .findFirst()
                 .map(FieldError::getDefaultMessage)
                 .orElse("Validation error");
 
-        ApiUtils.ApiResult<?> apiResult = ApiUtils.error(errorMessage, HttpStatus.BAD_REQUEST);
-        return new ResponseEntity<>(apiResult, HttpStatus.BAD_REQUEST);
+        return ApiResult.error(errorMessage, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity<?> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
-        ApiUtils.ApiResult<?> apiResult = ApiUtils.error("잘못된 요청값입니다.", HttpStatus.BAD_REQUEST);
-        return new ResponseEntity<>(apiResult, HttpStatus.BAD_REQUEST);
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResult<?> handleDataIntegrityViolationException(final DataIntegrityViolationException ex) {
+        return ApiResult.error("잘못된 요청값입니다.", HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
-    public ResponseEntity<?> accessDeniedError(AccessDeniedException e) {
-        ApiUtils.ApiResult<?> apiResult = ApiUtils.error("접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
-        return new ResponseEntity<>(apiResult, HttpStatus.FORBIDDEN);
+    @ResponseStatus(HttpStatus.FORBIDDEN)
+    public ApiResult<?> accessDeniedError(final AccessDeniedException e) {
+        return ApiResult.error("접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<?> unknownServerError(Exception e) {
-        ApiUtils.ApiResult<?> apiResult = ApiUtils.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
-        return new ResponseEntity<>(apiResult, HttpStatus.INTERNAL_SERVER_ERROR);
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiResult<?> unknownServerError(final Exception e) {
+        return ApiResult.error(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/theocean/fundering/global/errors/GlobalValidationHandler.java
+++ b/src/main/java/com/theocean/fundering/global/errors/GlobalValidationHandler.java
@@ -16,15 +16,14 @@ public class GlobalValidationHandler {
     }
 
     @Before("postMapping()")
-    public void validationAdvice(JoinPoint jp) {
-        Object[] args = jp.getArgs();
-        for (Object arg : args) {
-            if (arg instanceof Errors) {
-                Errors errors = (Errors) arg;
+    public void validationAdvice(final JoinPoint jp) {
+        final Object[] args = jp.getArgs();
+        for (final Object arg : args) {
+            if (arg instanceof final Errors errors) {
 
                 if (errors.hasErrors()) {
                     throw new Exception400(
-                            errors.getFieldErrors().get(0).getDefaultMessage()+":"+errors.getFieldErrors().get(0).getField()
+                            errors.getFieldErrors().get(0).getDefaultMessage() + ":" + errors.getFieldErrors().get(0).getField()
                     );
                 }
             }

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception400.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception400.java
@@ -8,15 +8,15 @@ import org.springframework.http.HttpStatus;
 @Getter
 public class Exception400 extends RuntimeException {
 
-    public Exception400(String message) {
+    public Exception400(final String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
+    public ApiUtils.ApiResult<?> body() {
         return ApiUtils.error(getMessage(), HttpStatus.BAD_REQUEST);
     }
 
-    public HttpStatus status(){
+    public HttpStatus status() {
         return HttpStatus.BAD_REQUEST;
     }
 }

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception401.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception401.java
@@ -6,15 +6,15 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public class Exception401 extends RuntimeException {
-    public Exception401(String message) {
+    public Exception401(final String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
+    public ApiUtils.ApiResult<?> body() {
         return ApiUtils.error(getMessage(), HttpStatus.UNAUTHORIZED);
     }
 
-    public HttpStatus status(){
+    public HttpStatus status() {
         return HttpStatus.UNAUTHORIZED;
     }
 }

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception403.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception403.java
@@ -3,17 +3,18 @@ package com.theocean.fundering.global.errors.exception;
 import com.theocean.fundering.global.utils.ApiUtils;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
+
 @Getter
 public class Exception403 extends RuntimeException {
-    public Exception403(String message) {
+    public Exception403(final String message) {
         super(message);
     }
 
-    public ApiUtils.ApiResult<?> body(){
+    public ApiUtils.ApiResult<?> body() {
         return ApiUtils.error(getMessage(), HttpStatus.FORBIDDEN);
     }
 
-    public HttpStatus status(){
+    public HttpStatus status() {
         return HttpStatus.FORBIDDEN;
     }
 }

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception404.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception404.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 // 권한 없음
 @Getter
 public class Exception404 extends RuntimeException {
-    public Exception404(String message) {
+    public Exception404(final String message) {
         super(message);
     }
 

--- a/src/main/java/com/theocean/fundering/global/errors/exception/Exception500.java
+++ b/src/main/java/com/theocean/fundering/global/errors/exception/Exception500.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 // 서버 에러
 @Getter
 public class Exception500 extends RuntimeException {
-    public Exception500(String message) {
+    public Exception500(final String message) {
         super(message);
     }
 

--- a/src/main/java/com/theocean/fundering/global/jwt/JwtProvider.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/JwtProvider.java
@@ -5,7 +5,6 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,14 +16,12 @@ import static org.hibernate.query.sqm.tree.SqmNode.log;
 @RequiredArgsConstructor
 @Component
 public class JwtProvider {
-    private static final Long ACCESS_EXP = 1000L * 60 * 60; // 1시간
-    private static final Long REFRESH_EXP = 1000L * 60 * 60 * 24 * 14; // 2주
-
-    private static final String EMAIL_CLAIM = "email";
-    private static final String TOKEN_PREFIX = "Bearer ";
     public static final String ACCESS_HEADER = "Authorization";
     public static final String REFRESH_HEADER = "Authorization-refresh";
-
+    private static final Long ACCESS_EXP = 1000L * 60 * 60; // 1시간
+    private static final Long REFRESH_EXP = 1000L * 60 * 60 * 24 * 14; // 2주
+    private static final String EMAIL_CLAIM = "email";
+    private static final String TOKEN_PREFIX = "Bearer ";
     private static final String ACCESS_SECRET = "MyAccessSecretKey1234";
     private static final String REFRESH_SECRET = "MyRefreshSecretKey1234";
 

--- a/src/main/java/com/theocean/fundering/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/filter/JwtAuthenticationFilter.java
@@ -1,8 +1,8 @@
 package com.theocean.fundering.global.jwt.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.domain.member.domain.Member;
+import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.global.errors.exception.Exception403;
 import com.theocean.fundering.global.jwt.JwtProvider;
 import com.theocean.fundering.global.utils.PasswordUtil;
@@ -10,7 +10,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -46,7 +45,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
         }
 
         final String refreshToken = jwtProvider.extractRefreshToken(request).orElse(null);
-        try{
+        try {
             // 원래 리소스 접근 시 refreshToken 없고 accessToken만 존재
             // accessToken 으로 이메일 비교 후 성공하면 인증 성공, 실패하면 다음 필터에서 인증 오류
             if (null == refreshToken) {
@@ -58,7 +57,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
                 checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
             }
             // 두 토큰 다 실패하면 다음 필터에서 403 에러
-        }catch(final Exception e){
+        } catch (final Exception e) {
             forbidden(response, new Exception403("권한이 없습니다."));
         }
     }

--- a/src/main/java/com/theocean/fundering/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/filter/JwtAuthenticationFilter.java
@@ -47,7 +47,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
         }
 
         final String refreshToken = jwtProvider.extractRefreshToken(request).orElse(null);
-        try{
+        try {
             // 원래 리소스 접근 시 refreshToken 없고 accessToken만 존재
             // accessToken 으로 이메일 비교 후 성공하면 인증 성공, 실패하면 다음 필터에서 인증 오류
             if (null == refreshToken) {
@@ -59,7 +59,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
                 checkRefreshTokenAndReIssueAccessToken(response, refreshToken);
             }
             // 두 토큰 다 실패하면 다음 필터에서 403 에러
-        }catch(final Exception e){
+        } catch (final Exception e) {
             forbidden(response, new Exception403("권한이 없습니다."));
         }
     }

--- a/src/main/java/com/theocean/fundering/global/jwt/handler/LoginFailureHandler.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/handler/LoginFailureHandler.java
@@ -1,7 +1,6 @@
 package com.theocean.fundering.global.jwt.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.theocean.fundering.global.errors.exception.Exception400;
 import com.theocean.fundering.global.errors.exception.Exception401;
 import com.theocean.fundering.global.utils.ApiUtils;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/theocean/fundering/global/jwt/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/handler/LoginSuccessHandler.java
@@ -4,7 +4,7 @@ package com.theocean.fundering.global.jwt.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.global.jwt.JwtProvider;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                 });
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json");
-        final String result = objectMapper.writeValueAsString(ApiUtils.success(SUCCESS_MESSAGE));
+        final String result = objectMapper.writeValueAsString(ApiResult.success(SUCCESS_MESSAGE));
         response.getWriter().write(result);
     }
 

--- a/src/main/java/com/theocean/fundering/global/jwt/service/LoginService.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/service/LoginService.java
@@ -1,10 +1,8 @@
 package com.theocean.fundering.global.jwt.service;
 
-import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.member.repository.MemberRepository;
 import com.theocean.fundering.global.jwt.userInfo.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/src/main/java/com/theocean/fundering/global/jwt/userInfo/CustomJsonUsernamePasswordAuthenticationFilter.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/userInfo/CustomJsonUsernamePasswordAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class CustomJsonUsernamePasswordAuthenticationFilter extends AbstractAuth
 
     @Override
     public Authentication attemptAuthentication(final HttpServletRequest request, final HttpServletResponse response) throws AuthenticationException, IOException {
-        if(null == request.getContentType() || !request.getContentType().equals(CONTENT_TYPE)  ) {
+        if (null == request.getContentType() || !request.getContentType().equals(CONTENT_TYPE)) {
             throw new AuthenticationServiceException("Authentication Content-Type not supported: " + request.getContentType());
         }
 

--- a/src/main/java/com/theocean/fundering/global/jwt/userInfo/CustomUserDetails.java
+++ b/src/main/java/com/theocean/fundering/global/jwt/userInfo/CustomUserDetails.java
@@ -24,6 +24,15 @@ public class CustomUserDetails implements UserDetails {
     private String password;
     private UserRole role;
 
+    public static CustomUserDetails from(final Member member) {
+        return builder()
+                .id(member.getUserId())
+                .email(member.getEmail())
+                .password(member.getPassword())
+                .role(member.getUserRole())
+                .build();
+    }
+
     public Long getId() {
         return id;
     }
@@ -61,14 +70,5 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
-    }
-
-    public static CustomUserDetails from(final Member member){
-        return CustomUserDetails.builder()
-                .id(member.getUserId())
-                .email(member.getEmail())
-                .password(member.getPassword())
-                .role(member.getUserRole())
-                .build();
     }
 }

--- a/src/main/java/com/theocean/fundering/global/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/theocean/fundering/global/oauth2/CustomOAuth2User.java
@@ -11,14 +11,14 @@ import java.util.Map;
 @Getter
 public class CustomOAuth2User extends DefaultOAuth2User {
 
-    private String email;
-    private UserRole role;
+    private final String email;
+    private final UserRole role;
 
-    public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
-                            Map<String, Object> attributes, String nameAttributeKey,
-                            String email, UserRole userRole) {
+    public CustomOAuth2User(final Collection<? extends GrantedAuthority> authorities,
+                            final Map<String, Object> attributes, final String nameAttributeKey,
+                            final String email, final UserRole userRole) {
         super(authorities, attributes, nameAttributeKey);
         this.email = email;
-        this.role = userRole;
+        role = userRole;
     }
 }

--- a/src/main/java/com/theocean/fundering/global/oauth2/OAuthAttributes.java
+++ b/src/main/java/com/theocean/fundering/global/oauth2/OAuthAttributes.java
@@ -1,31 +1,29 @@
 package com.theocean.fundering.global.oauth2;
 
+import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.domain.member.domain.constant.UserRole;
 import com.theocean.fundering.global.oauth2.userInfo.KakaoOAuth2UserInfo;
 import com.theocean.fundering.global.oauth2.userInfo.OAuth2UserInfo;
-import com.theocean.fundering.domain.member.domain.Member;
 import com.theocean.fundering.global.utils.PasswordUtil;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Map;
 
 @Getter
 public class OAuthAttributes {
 
-    private String nameAttributeKey;
-    private OAuth2UserInfo oauth2UserInfo;
+    private final String nameAttributeKey;
+    private final OAuth2UserInfo oauth2UserInfo;
 
     @Builder
-    public OAuthAttributes(String nameAttributeKey, OAuth2UserInfo oauth2UserInfo) {
+    public OAuthAttributes(final String nameAttributeKey, final OAuth2UserInfo oauth2UserInfo) {
         this.nameAttributeKey = nameAttributeKey;
         this.oauth2UserInfo = oauth2UserInfo;
     }
 
-    public static OAuthAttributes of(String userNameAttributeName, Map<String, Object> attributes) {
-        return OAuthAttributes.builder()
+    public static OAuthAttributes of(final String userNameAttributeName, final Map<String, Object> attributes) {
+        return builder()
                 .nameAttributeKey(userNameAttributeName)
                 .oauth2UserInfo(new KakaoOAuth2UserInfo(attributes))
                 .build();

--- a/src/main/java/com/theocean/fundering/global/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/theocean/fundering/global/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,7 +1,6 @@
 package com.theocean.fundering.global.oauth2.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.theocean.fundering.global.errors.exception.Exception400;
 import com.theocean.fundering.global.errors.exception.Exception401;
 import com.theocean.fundering.global.utils.ApiUtils;
 import jakarta.servlet.ServletException;
@@ -21,13 +20,14 @@ import java.io.IOException;
 public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
     private final String FAILURE_MESSAGE = "아이디나 비밀번호가 잘못 되었습니다.";
     private final ObjectMapper objectMapper;
+
     @Override
-    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+    public void onAuthenticationFailure(final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException exception) throws IOException, ServletException {
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         log.info("로그인에 실패했습니다. 메시지 : {}", exception.getMessage());
-        String result = objectMapper.writeValueAsString(ApiUtils.error(FAILURE_MESSAGE, new Exception401("아이디나 비밀번호가 잘못 되었습니다.").status()));
+        final String result = objectMapper.writeValueAsString(ApiUtils.error(FAILURE_MESSAGE, new Exception401("아이디나 비밀번호가 잘못 되었습니다.").status()));
         response.getWriter().write(result);
     }
 }

--- a/src/main/java/com/theocean/fundering/global/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/theocean/fundering/global/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -3,7 +3,7 @@ package com.theocean.fundering.global.oauth2.handler;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.theocean.fundering.global.jwt.JwtProvider;
 import com.theocean.fundering.global.oauth2.CustomOAuth2User;
-import com.theocean.fundering.global.utils.ApiUtils;
+import com.theocean.fundering.global.utils.ApiResult;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -25,23 +25,23 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private final String SUCCESS_MESSAGE = "로그인에 성공했습니다.";
 
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+    public void onAuthenticationSuccess(final HttpServletRequest request, final HttpServletResponse response, final Authentication authentication) throws IOException, ServletException {
         log.info("OAuth2Login Success");
         try {
-            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+            final CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
             loginSuccess(response, oAuth2User);
             response.setCharacterEncoding("UTF-8");
             response.setContentType("application/json");
-            String result = objectMapper.writeValueAsString(ApiUtils.success(SUCCESS_MESSAGE));
+            final String result = objectMapper.writeValueAsString(ApiResult.success(SUCCESS_MESSAGE));
             response.getWriter().write(result);
-        } catch (Exception e) {
+        } catch (final Exception e) {
             throw e;
         }
     }
 
-    private void loginSuccess(HttpServletResponse response, CustomOAuth2User oAuth2User) throws IOException {
-        String accessToken = jwtProvider.createAccessToken(oAuth2User.getEmail());
-        String refreshToken = jwtProvider.createRefreshToken(oAuth2User.getEmail());
+    private void loginSuccess(final HttpServletResponse response, final CustomOAuth2User oAuth2User) throws IOException {
+        final String accessToken = jwtProvider.createAccessToken(oAuth2User.getEmail());
+        final String refreshToken = jwtProvider.createRefreshToken(oAuth2User.getEmail());
         response.setHeader(JwtProvider.ACCESS_HEADER, accessToken);
         response.setHeader(JwtProvider.REFRESH_HEADER, refreshToken);
 

--- a/src/main/java/com/theocean/fundering/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/theocean/fundering/global/oauth2/service/CustomOAuth2UserService.java
@@ -25,18 +25,18 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private final MemberRepository memberRepository;
 
     @Override
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    public OAuth2User loadUser(final OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         log.info("CustomOAuth2UserService.loadUser 실행");
 
-        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
-        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        final OAuth2User oAuth2User = delegate.loadUser(userRequest);
 
-        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
-        Map<String, Object> attributes = oAuth2User.getAttributes();
+        final String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+        final Map<String, Object> attributes = oAuth2User.getAttributes();
 
-        OAuthAttributes extractedAttributes = OAuthAttributes.of(userNameAttributeName, attributes);
+        final OAuthAttributes extractedAttributes = OAuthAttributes.of(userNameAttributeName, attributes);
 
-        Member createdUser = getUser(extractedAttributes);
+        final Member createdUser = getUser(extractedAttributes);
 
         return new CustomOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(createdUser.getUserRole().name())),
@@ -47,17 +47,17 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         );
     }
 
-    private Member getUser(OAuthAttributes attributes) {
-        Member findMember = memberRepository.findById(attributes.getOauth2UserInfo().getId()).orElse(null);
+    private Member getUser(final OAuthAttributes attributes) {
+        final Member findMember = memberRepository.findById(attributes.getOauth2UserInfo().getId()).orElse(null);
 
-        if (findMember == null) {
+        if (null == findMember) {
             return saveMember(attributes);
         }
         return findMember;
     }
 
-    private Member saveMember(OAuthAttributes attributes) {
-        Member newMember = attributes.toEntity();
+    private Member saveMember(final OAuthAttributes attributes) {
+        final Member newMember = attributes.toEntity();
         return memberRepository.save(newMember);
     }
 }

--- a/src/main/java/com/theocean/fundering/global/oauth2/userInfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/theocean/fundering/global/oauth2/userInfo/KakaoOAuth2UserInfo.java
@@ -4,7 +4,7 @@ import java.util.Map;
 
 public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
 
-    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+    public KakaoOAuth2UserInfo(final Map<String, Object> attributes) {
         super(attributes);
     }
 
@@ -15,10 +15,10 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getNickname() {
-        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        final Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        final Map<String, Object> profile = (Map<String, Object>) account.get("profile");
 
-        if (account == null || profile == null) {
+        if (null == account || null == profile) {
             return null;
         }
 
@@ -27,10 +27,10 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getImageUrl() {
-        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        final Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        final Map<String, Object> profile = (Map<String, Object>) account.get("profile");
 
-        if (account == null || profile == null) {
+        if (null == account || null == profile) {
             return null;
         }
 
@@ -39,10 +39,10 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo {
 
     @Override
     public String getEmail() {
-        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+        final Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        final Map<String, Object> profile = (Map<String, Object>) account.get("profile");
 
-        if (account == null || profile == null) {
+        if (null == account || null == profile) {
             return null;
         }
 

--- a/src/main/java/com/theocean/fundering/global/oauth2/userInfo/OAuth2UserInfo.java
+++ b/src/main/java/com/theocean/fundering/global/oauth2/userInfo/OAuth2UserInfo.java
@@ -6,7 +6,7 @@ public abstract class OAuth2UserInfo {
 
     protected Map<String, Object> attributes;
 
-    public OAuth2UserInfo(Map<String, Object> attributes) {
+    protected OAuth2UserInfo(final Map<String, Object> attributes) {
         this.attributes = attributes;
     }
 

--- a/src/main/java/com/theocean/fundering/global/utils/AWSS3Uploader.java
+++ b/src/main/java/com/theocean/fundering/global/utils/AWSS3Uploader.java
@@ -9,13 +9,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.S3Uri;
-import software.amazon.awssdk.services.s3.S3Utilities;
 import software.amazon.awssdk.services.s3.model.GetUrlRequest;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -23,21 +20,21 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class AWSS3Uploader {
+    private final AWSS3Config awss3Config;
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
-    private final AWSS3Config awss3Config;
 
-    public String uploadToS3(MultipartFile mFile) {
-        S3Client s3Client = awss3Config.s3Client();
-        String fileName = UUID.randomUUID() + "_" + mFile.getOriginalFilename();
+    public String uploadToS3(final MultipartFile mFile) {
+        final S3Client s3Client = awss3Config.s3Client();
+        final String fileName = UUID.randomUUID() + "_" + mFile.getOriginalFilename();
         try {
-            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+            final PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(fileName)
                     .acl(ObjectCannedACL.PUBLIC_READ)
                     .build();
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(mFile.getInputStream(), mFile.getInputStream().available()));
-        }catch (IOException e){
+        } catch (final IOException e) {
             throw new Exception500("file upload error");
         }
         return s3Client.utilities().getUrl(GetUrlRequest.builder()

--- a/src/main/java/com/theocean/fundering/global/utils/ApiResult.java
+++ b/src/main/java/com/theocean/fundering/global/utils/ApiResult.java
@@ -5,24 +5,25 @@ import lombok.Getter;
 import lombok.Setter;
 import org.springframework.http.HttpStatus;
 
-public class ApiUtils {
+@Getter
+@Setter
+@AllArgsConstructor
+public class ApiResult<T> {
+    private final boolean success;
+    private final T response;
+    private final ApiError error;
 
-    public static <T> ApiResult<T> success(T response) {
+    public static <T> ApiResult<T> success(final T response) {
         return new ApiResult<>(true, response, null);
     }
 
-    public static ApiResult<?> error(String message, HttpStatus status) {
+    public static ApiResult<?> error(final String message, final HttpStatus status) {
         return new ApiResult<>(false, null, new ApiError(message, status.value()));
     }
 
-    @Getter @Setter @AllArgsConstructor
-    public static class ApiResult<T> {
-        private final boolean success;
-        private final T response;
-        private final ApiError error;
-    }
-
-    @Getter @Setter @AllArgsConstructor
+    @Getter
+    @Setter
+    @AllArgsConstructor
     public static class ApiError {
         private final String message;
         private final int status;

--- a/src/main/java/com/theocean/fundering/global/utils/HTMLUtils.java
+++ b/src/main/java/com/theocean/fundering/global/utils/HTMLUtils.java
@@ -8,10 +8,10 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class HTMLUtils {
-    public String markdownToHTML(String md){
-        Parser parser = Parser.builder().build();
-        HtmlRenderer renderer = HtmlRenderer.builder().build();
-        Node content = parser.parse(md);
+    public String markdownToHTML(final String md) {
+        final Parser parser = Parser.builder().build();
+        final HtmlRenderer renderer = HtmlRenderer.builder().build();
+        final Node content = parser.parse(md);
         return renderer.render(content);
     }
 

--- a/src/main/java/com/theocean/fundering/global/utils/ImageUploadController.java
+++ b/src/main/java/com/theocean/fundering/global/utils/ImageUploadController.java
@@ -1,0 +1,26 @@
+package com.theocean.fundering.global.utils;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+public class ImageUploadController {
+
+    private final AWSS3Uploader awss3Uploader;
+
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/uploadImg")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResult<?> uploadImage(@RequestPart("image") final MultipartFile img) {
+        final String result = awss3Uploader.uploadToS3(img);
+        return ApiResult.success(result);
+    }
+}

--- a/src/main/java/com/theocean/fundering/global/utils/PasswordUtil.java
+++ b/src/main/java/com/theocean/fundering/global/utils/PasswordUtil.java
@@ -2,11 +2,12 @@ package com.theocean.fundering.global.utils;
 
 import java.util.Random;
 
-public class PasswordUtil {
+public enum PasswordUtil {
+    ;
 
     public static String generateRandomPassword() {
         int index = 0;
-        char[] charSet = new char[] {
+        final char[] charSet = {
                 '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
                 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
                 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
@@ -14,11 +15,11 @@ public class PasswordUtil {
                 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
         };
 
-        StringBuffer password = new StringBuffer();
-        Random random = new Random();
+        final StringBuffer password = new StringBuffer();
+        final Random random = new Random();
 
-        for (int i = 0; i < 8 ; i++) {
-            double rd = random.nextDouble();
+        for (int i = 0; 8 > i; i++) {
+            final double rd = random.nextDouble();
             index = (int) (charSet.length * rd);
 
             password.append(charSet[index]);

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ server:
   port: 8080
 spring:
   datasource:
-#    url: jdbc:h2:tcp://localhost/~/fundering;MODE=MySQL
+    #    url: jdbc:h2:tcp://localhost/~/fundering;MODE=MySQL
     url: jdbc:h2:mem:test;MODE=MySQL
     username: sa
     password:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -6,7 +6,7 @@ server:
   port: 8080
 spring:
   datasource:
-#    url: jdbc:h2:tcp://localhost/~/fundering;MODE=MySQL
+    #    url: jdbc:h2:tcp://localhost/~/fundering;MODE=MySQL
     url: jdbc:h2:mem:test;MODE=MySQL
     username: sa
     password:

--- a/src/test/java/com/theocean/fundering/FunderingApplicationTests.java
+++ b/src/test/java/com/theocean/fundering/FunderingApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class FunderingApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/com/theocean/fundering/celebrity/CelebrityControllerTest.java
+++ b/src/test/java/com/theocean/fundering/celebrity/CelebrityControllerTest.java
@@ -7,13 +7,10 @@ import com.theocean.fundering.domain.celebrity.domain.constant.CelebGender;
 import com.theocean.fundering.domain.celebrity.domain.constant.CelebType;
 import com.theocean.fundering.domain.celebrity.dto.CelebRequestDTO;
 import com.theocean.fundering.domain.celebrity.service.CelebService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
@@ -23,7 +20,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import static org.mockito.BDDMockito.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,22 +30,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class CelebrityControllerTest {
     private static final String CELEB_NAME = "아이유";
     private static final String PROFILE_IMAGE = "profile.jpg";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper om;
-
-    @MockBean
-    private CelebService celebService;
-
     private final Celebrity celeb = Celebrity.builder()
             .celebName(CELEB_NAME)
             .celebGender(CelebGender.FEMALE)
             .celebType(CelebType.SINGER)
             .profileImage(PROFILE_IMAGE)
             .build();
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper om;
+    @MockBean
+    private CelebService celebService;
 
     @WithMockUser
     @Test

--- a/src/test/java/com/theocean/fundering/celebrity/CelebrityControllerTest.java
+++ b/src/test/java/com/theocean/fundering/celebrity/CelebrityControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -29,22 +28,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class CelebrityControllerTest {
     private static final String CELEB_NAME = "아이유";
     private static final String PROFILE_IMAGE = "profile.jpg";
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private ObjectMapper om;
-
-    @MockBean
-    private CelebService celebService;
-
     private final Celebrity celeb = Celebrity.builder()
             .celebName(CELEB_NAME)
             .celebGender(CelebGender.FEMALE)
             .celebType(CelebType.SINGER)
             .profileImage(PROFILE_IMAGE)
             .build();
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper om;
+    @MockBean
+    private CelebService celebService;
 
     @WithMockUser
     @Test

--- a/src/test/java/com/theocean/fundering/comment/CommentControllerTest.java
+++ b/src/test/java/com/theocean/fundering/comment/CommentControllerTest.java
@@ -11,13 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -41,11 +40,11 @@ public class CommentControllerTest {
 
 
     @DisplayName("USER role을 지닌 유저는 댓글 생성에 성공합니다.")
-    @WithMockUser(roles = {"USER"})  // USER 권한을 가진 사용자로 설정
+    @WithMockUser(roles = "USER")  // USER 권한을 가진 사용자로 설정
     @Test
     public void createComment_withUserRole_shouldSucceed() throws Exception {
 
-        this.mockMvc.perform(post("/posts/{postId}/comments", 1L).with(csrf())
+        mockMvc.perform(post("/posts/{postId}/comments", 1L).with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"test comment\"}"))
                 .andExpect(status().isOk());
@@ -55,7 +54,7 @@ public class CommentControllerTest {
     @WithMockUser(roles = "GUEST")  // GUEST 권한을 가진 사용자로 설정
     @Test
     public void createComment_withGuestRole_shouldFail() throws Exception {
-        this.mockMvc.perform(post("/posts/{postId}/comments", 1L)
+        mockMvc.perform(post("/posts/{postId}/comments", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"content\":\"test comment\"}"))
                 .andExpect(status().isForbidden());  // 403 Forbidden 예상
@@ -65,7 +64,7 @@ public class CommentControllerTest {
     @WithMockUser(roles = "USER")  // USER 권한을 가진 사용자로 설정
     @Test
     public void deleteComment_withUserRole_shouldSucceed() throws Exception {
-        this.mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", 1L, 1L).with(csrf()))
+        mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", 1L, 1L).with(csrf()))
                 .andExpect(status().isOk());
     }
 
@@ -73,7 +72,7 @@ public class CommentControllerTest {
     @WithMockUser(roles = "GUEST")  // GUEST 권한을 가진 사용자로 설정
     @Test
     public void deleteComment_withGuestRole_shouldFail() throws Exception {
-        this.mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", 1L, 1L))
+        mockMvc.perform(delete("/posts/{postId}/comments/{commentId}", 1L, 1L))
                 .andExpect(status().isForbidden());  // 403 Forbidden 예상
     }
 
@@ -82,8 +81,8 @@ public class CommentControllerTest {
     @Test
     public void createComment_withEmptyContent_shouldReturn400() throws Exception {
         // Given
-        CommentRequest.SaveDTO request = CommentRequest.SaveDTO.builder().content("").build();
-        String jsonRequest = new ObjectMapper().writeValueAsString(request);
+        final CommentRequest.SaveDTO request = CommentRequest.SaveDTO.builder().content("").build();
+        final String jsonRequest = new ObjectMapper().writeValueAsString(request);
 
         // When & Then
         mockMvc.perform(post("/posts/1/comments").with(csrf())

--- a/src/test/java/com/theocean/fundering/member/MemberControllerTest.java
+++ b/src/test/java/com/theocean/fundering/member/MemberControllerTest.java
@@ -27,8 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -189,7 +189,7 @@ class MemberControllerTest {
     @WithMockUser
     @Transactional
     @Test
-    void role_success_test() throws Exception{
+    void role_success_test() throws Exception {
 
         //given
         //when
@@ -205,7 +205,7 @@ class MemberControllerTest {
     @DisplayName("User 권한 접근 실패 테스트")
     @Transactional
     @Test
-    void role_fail_test() throws Exception{
+    void role_fail_test() throws Exception {
 
         //given
         //when

--- a/src/test/java/com/theocean/fundering/member/MemberControllerTest.java
+++ b/src/test/java/com/theocean/fundering/member/MemberControllerTest.java
@@ -25,8 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -192,7 +192,7 @@ class MemberControllerTest {
     @WithMockUser
     @Transactional
     @Test
-    void role_success_test() throws Exception{
+    void role_success_test() throws Exception {
 
         //given
         //when
@@ -208,7 +208,7 @@ class MemberControllerTest {
     @DisplayName("User 권한 접근 실패 테스트")
     @Transactional
     @Test
-    void role_fail_test() throws Exception{
+    void role_fail_test() throws Exception {
 
         //given
         //when
@@ -218,6 +218,6 @@ class MemberControllerTest {
         );
         //then
         result.andExpect(status().isForbidden())
-                .andExpect(MockMvcResultMatchers.jsonPath("$.success").value("false"));;
+                .andExpect(MockMvcResultMatchers.jsonPath("$.success").value("false"));
     }
 }

--- a/src/test/java/com/theocean/fundering/post/PostTest.java
+++ b/src/test/java/com/theocean/fundering/post/PostTest.java
@@ -10,7 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 public class PostTest {
 
     @Test
-    public void findAll_test() throws Exception{
+    public void findAll_test() throws Exception {
 
     }
 }


### PR DESCRIPTION
## 주요 사항
- 멘토님의 코드 인스펙션을 기반으로 전체 소스 코드 컨벤션 통일
- 기존 ApiUtils -> ApiResult로 리팩토링 및 각 API 리턴 타입을 ApiResult로 변경
- "/uploadImg" API를 global 패키지로 분리 및 이동
- Post 엔티티에 펀딩 상태를 명시하는 컬럼 추가 및 열거형 상태 코드 PostStatus 추가

## 스크린샷


## 궁금한 점


### 관련 이슈
이슈를 해결한 경우 `close #issue-number`