### PR TITLE
출금 승인 로직 추가

### DIFF
--- a/src/main/java/com/theocean/fundering/InitialDataInjection.java
+++ b/src/main/java/com/theocean/fundering/InitialDataInjection.java
@@ -42,9 +42,9 @@ public class InitialDataInjection {
     return args -> {
       if (memberRepository.count() == 0) {
         String query1 =
-            "INSERT INTO member (created_at, modified_at, phone_number, nickname, email, password, profile_image, refresh_token, user_role) VALUES (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '01012341234', '1번유저', 'test1@naver.com', 'test1234!', '프로필_URL_1', NULL, 'USER')";
+            "INSERT INTO member (created_at, modified_at, phone_number, nickname, email, password, profile_image, refresh_token, user_role) VALUES (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '01012341234', '1번유저', 'test1@naver.com', '{bcrypt}$2a$10$FkEVe6W5yp7dfMeyuK5j.O8EnIwRlHW0GlK8.xerwgb/NoZhyJInG', '프로필_URL_1', NULL, 'USER')";
         String query2 =
-            "INSERT INTO member (created_at, modified_at, phone_number, nickname, email, password, profile_image, refresh_token, user_role) VALUES (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '01043211234', '2번유저', 'test2@naver.com', 'test1234@', '프로필_URL_2', NULL, 'USER')";
+            "INSERT INTO member (created_at, modified_at, phone_number, nickname, email, password, profile_image, refresh_token, user_role) VALUES (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, '01043211234', '2번유저', 'test2@naver.com', '{bcrypt}$2a$10$m.2s7slIMNhoa5jMcTSssOq4BEmCo1Cy0P5MpYITUrfmMCC3OvRLK', '프로필_URL_2', NULL, 'USER')";
 
         jdbcTemplate.update(query1);
         jdbcTemplate.update(query2);

--- a/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
+++ b/src/main/java/com/theocean/fundering/domain/account/domain/Account.java
@@ -33,6 +33,10 @@ public class Account {
     @Column(name = "balance")
     private int balance;
 
+    public void updateBalance(int balance) {
+        this.balance = balance;
+    }
+
     @Builder
     public Account(final Long managerId, final Long postId) {
         this.managerId = managerId;

--- a/src/main/java/com/theocean/fundering/domain/evidence/controller/EvidenceController.java
+++ b/src/main/java/com/theocean/fundering/domain/evidence/controller/EvidenceController.java
@@ -37,7 +37,7 @@ public class EvidenceController {
                     content = @Content(
                             mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
                             schema = @Schema(type = "string", format = "binary"),
-                            encoding = @Encoding(name = "image", contentType = "image/jpeg")
+                            encoding = @Encoding(name = "image", contentType = "image/png")
                     )
             )
     )

--- a/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
+++ b/src/main/java/com/theocean/fundering/domain/withdrawal/domain/Withdrawal.java
@@ -69,8 +69,9 @@ public class Withdrawal extends AuditingFields {
         status = ApprovalStatus.PENDING;
     }
 
-    public void approveWithdrawal() {
+    public void approveWithdrawal(int balance) {
         status = ApprovalStatus.APPROVED;
+        this.balance = balance;
     }
 
     public void denyWithdrawal(){


### PR DESCRIPTION
## 주요 사항
- 출금 신청이 승인될 때, 출금 이후 잔액을 출금 신청서와 계좌에 업데이트해주었습니다.
- 기존 초기 회원 데이터의 비밀번호를 인코딩해서 주입하여 로그인할 수 있도록 했습니다.
  - 1번유저 비밀번호: test1234!
  - 2번유저 비밀번호: test1234@


## 스크린샷

## 궁금한 점

### 관련 이슈
