### PR TITLE
찜하기 관련 요소 이름 수정 및 post 무한 스크롤 로직 수정

### DIFF
--- a/src/main/java/com/theocean/fundering/domain/post/controller/HeartController.java
+++ b/src/main/java/com/theocean/fundering/domain/post/controller/HeartController.java
@@ -33,12 +33,11 @@ public class HeartController {
 
     @Operation(summary = "찜하기 취소", description = "펀딩 id를 기반으로 펀딩 찜을 취소한다.")
     @PreAuthorize("hasRole('ROLE_USER')")
-    @DeleteMapping("/posts/{postId}/unHeart")
+    @PostMapping("/posts/{postId}/unHeart")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResult<?> unHeart(@AuthenticationPrincipal final CustomUserDetails userDetails,
+    public ApiResult<?> subtractHeart(@AuthenticationPrincipal final CustomUserDetails userDetails,
                                 @PathVariable final Long postId) {
-
-        heartService.unHeart(userDetails.getId(), postId);
+        heartService.subtractHeart(userDetails.getId(), postId);
         return ApiResult.success(null);
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
+++ b/src/main/java/com/theocean/fundering/domain/post/controller/PostController.java
@@ -29,12 +29,11 @@ public class PostController {
     @GetMapping("/posts")
     @ResponseStatus(HttpStatus.OK)
     public ApiResult<?> findAll(@AuthenticationPrincipal final CustomUserDetails userDetails,
-                                @Parameter(description = "무한 스크롤 기준점") @RequestParam(value = "postId", required = false) final Long postId,
                                 @Parameter(description = "page, size, sort") final Pageable pageable){
         String memberEmail = null;
         if (null != userDetails)
             memberEmail = userDetails.getEmail();
-        final var responseDTO = postService.findAll(memberEmail, postId, pageable);
+        final var responseDTO = postService.findAll(memberEmail, pageable);
         return ApiResult.success(responseDTO);
     }
 
@@ -100,13 +99,12 @@ public class PostController {
     @GetMapping("/posts/search/keyword")
     @ResponseStatus(HttpStatus.OK)
     public ApiResult<?> searchPostByKeyword(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                            @Parameter(description = "무한 스크롤 기준점") @RequestParam(value = "postId", required = false) final Long postId,
                                             @Parameter(description = "검색어") @RequestParam("keyword") final String keyword,
                                             @Parameter(description = "page, size, sort") final Pageable pageable){
         String memberEmail = null;
         if (null != userDetails)
             memberEmail = userDetails.getEmail();
-        final var response = postService.findAllByKeyword(memberEmail, postId, keyword, pageable);
+        final var response = postService.findAllByKeyword(memberEmail, keyword, pageable);
         return ApiResult.success(response);
     }
 
@@ -114,13 +112,12 @@ public class PostController {
     @GetMapping("/posts/search/nickname")
     @ResponseStatus(HttpStatus.OK)
     public ApiResult<?> searchPostByNickname(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                             @Parameter(description = "무한 스크롤 기준점") @RequestParam(value = "postId", required = false) final Long postId,
                                              @Parameter(description = "사용자 닉네임") @RequestParam("nickname") final String nickname,
                                              @Parameter(description = "page, size, sort") final Pageable pageable){
         String memberEmail = null;
         if (null != userDetails)
             memberEmail = userDetails.getEmail();
-        final var response = postService.findAllByWriterName(memberEmail, postId, nickname, pageable);
+        final var response = postService.findAllByWriterName(memberEmail, nickname, pageable);
         return ApiResult.success(response);
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/domain/Post.java
+++ b/src/main/java/com/theocean/fundering/domain/post/domain/Post.java
@@ -131,7 +131,7 @@ public class Post extends AuditingFields {
         heartCount += 1;
     }
 
-    public void minusHeartCount() {
+    public void subtractHeartCount() {
         heartCount -= 1;
     }
 

--- a/src/main/java/com/theocean/fundering/domain/post/repository/HeartRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/HeartRepository.java
@@ -9,10 +9,10 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface HeartRepository extends JpaRepository<Heart, Long> {
-    @Query("SELECT COUNT(*) FROM Heart h WHERE h.postId = :postId")
+    @Query("SELECT IFNULL(COUNT(*), 0) FROM Heart h WHERE h.postId = :postId")
     int countByPostId(@Param("postId") Long postId);
 
-    @Query("SELECT COUNT(*) FROM Heart h WHERE h.postId = :postId AND h.memberId = :memberId")
+    @Query("SELECT IFNULL(COUNT(*), 0) FROM Heart h WHERE h.postId = :postId AND h.memberId = :memberId")
     int countByPostIdAndHeartId(@Param("postId") Long postId, @Param("memberId") Long memberId);
 
     @Query("SELECT h.postId FROM Heart h WHERE h.memberId = :memberId")
@@ -20,10 +20,10 @@ public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     @Modifying
     @Query(value = "INSERT INTO heart(member_id, post_id) VALUES(:memberId, :postId)", nativeQuery = true)
-    void saveHeart(@Param("memberId") Long memberId, @Param("postId") Long postId);
+    void addHeart(@Param("memberId") Long memberId, @Param("postId") Long postId);
 
     @Modifying
     @Query(value = "DELETE FROM heart WHERE member_id = :memberId AND post_id = :postId", nativeQuery = true)
-    void saveUnHeart(@Param("memberId") Long memberId, @Param("postId") Long postId);
+    void subtractHeart(@Param("memberId") Long memberId, @Param("postId") Long postId);
 }
 

--- a/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepository.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepository.java
@@ -6,9 +6,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface PostQuerydslRepository {
-    Slice<PostResponse.FindAllDTO> findAllInfiniteScroll(@Nullable Long postId, Pageable pageable);
+    Slice<PostResponse.FindAllDTO> findAllInfiniteScroll(Pageable pageable);
 
-    Slice<PostResponse.FindAllDTO> findAllByWriterName(@Nullable Long postId, String nickname, Pageable pageable);
+    Slice<PostResponse.FindAllDTO> findAllByWriterName(String nickname, Pageable pageable);
 
-    Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable Long postId, String keyword, Pageable pageable);
+    Slice<PostResponse.FindAllDTO> findAllByKeyword(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepositoryImpl.java
+++ b/src/main/java/com/theocean/fundering/domain/post/repository/PostQuerydslRepositoryImpl.java
@@ -24,7 +24,7 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Slice<PostResponse.FindAllDTO> findAllInfiniteScroll(@Nullable final Long postId, final Pageable pageable) {
+    public Slice<PostResponse.FindAllDTO> findAllInfiniteScroll(final Pageable pageable) {
         final OrderSpecifier[] orderSpecifiers = createOrderSpecifier(pageable.getSort());
 
         final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
@@ -44,17 +44,16 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository {
                         post.modifiedAt.as("modifiedAt"),
                         post.heartCount.as("heartCount")))
                 .from(post)
-                .where(ltPostId(postId))
+                .offset(pageable.getOffset())
                 .orderBy(orderSpecifiers)
-                .limit(pageable.getPageSize())
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
 
-        final boolean hasNext = contents.size() > pageable.getPageSize();
-        return new SliceImpl<>(contents, pageable, hasNext);
+        return new SliceImpl<>(contents, pageable, hasNext(contents, pageable));
     }
 
     @Override
-    public Slice<PostResponse.FindAllDTO> findAllByWriterName(@Nullable final Long postId, final String nickname, final Pageable pageable) {
+    public Slice<PostResponse.FindAllDTO> findAllByWriterName(final String nickname, final Pageable pageable) {
         final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.postId.as("postId"),
@@ -72,16 +71,17 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository {
                         post.modifiedAt.as("modifiedAt"),
                         post.heartCount.as("heartCount")))
                 .from(post)
-                .where(ltPostId(postId), eqWriter(nickname))
+                .where(eqWriter(nickname))
+                .offset(pageable.getOffset())
                 .orderBy(post.postId.desc())
-                .limit(pageable.getPageSize())
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
-        final boolean hasNext = contents.size() > pageable.getPageSize();
-        return new SliceImpl<>(contents, pageable, hasNext);
+
+        return new SliceImpl<>(contents, pageable, hasNext(contents, pageable));
     }
 
     @Override
-    public Slice<PostResponse.FindAllDTO> findAllByKeyword(@Nullable final Long postId, final String keyword, final Pageable pageable) {
+    public Slice<PostResponse.FindAllDTO> findAllByKeyword(final String keyword, final Pageable pageable) {
         final List<PostResponse.FindAllDTO> contents = jpaQueryFactory
                 .select(Projections.bean(PostResponse.FindAllDTO.class,
                         post.postId.as("postId"),
@@ -99,12 +99,13 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository {
                         post.modifiedAt.as("modifiedAt"),
                         post.heartCount.as("heartCount")))
                 .from(post)
-                .where(ltPostId(postId), containKeyword(keyword))
+                .where(containKeyword(keyword))
+                .offset(pageable.getOffset())
                 .orderBy(post.postId.desc())
-                .limit(pageable.getPageSize())
+                .limit(pageable.getPageSize() + 1)
                 .fetch();
-        final boolean hasNext = contents.size() > pageable.getPageSize();
-        return new SliceImpl<>(contents, pageable, hasNext);
+
+        return new SliceImpl<>(contents, pageable, hasNext(contents, pageable));
     }
 
     private OrderSpecifier[] createOrderSpecifier(final Sort sort) {
@@ -133,6 +134,14 @@ public class PostQuerydslRepositoryImpl implements PostQuerydslRepository {
 
     private BooleanExpression containKeyword(final String keyword) {
         return post.title.contains(keyword);
+    }
+
+    private boolean hasNext(List<?> contents, Pageable pageable){
+        if (contents.size() > pageable.getPageSize()) {
+            contents.remove(contents.size() - 1);
+            return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/theocean/fundering/domain/post/service/HeartService.java
+++ b/src/main/java/com/theocean/fundering/domain/post/service/HeartService.java
@@ -20,16 +20,17 @@ public class HeartService {
         final Post post = postRepository.findById(postId).orElseThrow(
                 () -> new Exception400("")
         );
-        heartRepository.saveHeart(memberId, post.getPostId());
+        heartRepository.addHeart(memberId, post.getPostId());
         post.addHeartCount();
+
     }
 
     @Transactional
-    public void unHeart(final Long memberId, final Long postId) {
+    public void subtractHeart(final Long memberId, final Long postId) {
         final Post post = postRepository.findById(postId).orElseThrow(
                 () -> new Exception400("")
         );
-        heartRepository.saveUnHeart(memberId, post.getPostId());
-        post.minusHeartCount();
+        heartRepository.subtractHeart(memberId, post.getPostId());
+        post.subtractHeartCount();
     }
 }

--- a/src/main/java/com/theocean/fundering/domain/post/service/PostService.java
+++ b/src/main/java/com/theocean/fundering/domain/post/service/PostService.java
@@ -77,10 +77,8 @@ public class PostService {
     }
 
     @Transactional
-    public PageResponse<PostResponse.FindAllDTO> findAll(String email, @Nullable Long postId, Pageable pageable){
-        if (null == postId)
-            postId = postRepository.findLastPostId();
-        var postList = postRepository.findAllInfiniteScroll(postId, pageable);
+    public PageResponse<PostResponse.FindAllDTO> findAll(String email, Pageable pageable){
+        var postList = postRepository.findAllInfiniteScroll(pageable);
         if (null != email){
             Member member = memberRepository.findByEmail(email).orElseThrow();
             postList.stream().filter(p -> 0 != heartRepository.countByPostIdAndHeartId(p.getPostId(), member.getUserId())).forEach(p -> p.setHeart(true));
@@ -90,10 +88,8 @@ public class PostService {
     }
 
     @Transactional
-    public PageResponse<PostResponse.FindAllDTO> findAllByWriterName(String email, @Nullable Long postId, String nickname, Pageable pageable){
-        if (null == postId)
-            postId = postRepository.findLastPostId();
-        var postList = postRepository.findAllByWriterName(postId, nickname, pageable);
+    public PageResponse<PostResponse.FindAllDTO> findAllByWriterName(String email, String nickname, Pageable pageable){
+        var postList = postRepository.findAllByWriterName(nickname, pageable);
         if (null != email){
             Member member = memberRepository.findByEmail(email).orElseThrow();
             postList.stream().filter(p -> 0 != heartRepository.countByPostIdAndHeartId(p.getPostId(), member.getUserId())).forEach(p -> p.setHeart(true));
@@ -123,10 +119,8 @@ public class PostService {
     }
 
     @Transactional
-    public PageResponse<PostResponse.FindAllDTO> findAllByKeyword(String email, @Nullable Long postId, String keyword, Pageable pageable){
-        if (null == postId)
-            postId = postRepository.findLastPostId();
-        var postList = postRepository.findAllByKeyword(postId, keyword, pageable);
+    public PageResponse<PostResponse.FindAllDTO> findAllByKeyword(String email, String keyword, Pageable pageable){
+        var postList = postRepository.findAllByKeyword(keyword, pageable);
         if (null != email){
             Member member = memberRepository.findByEmail(email).orElseThrow();
             postList.stream().filter(p -> 0 != heartRepository.countByPostIdAndHeartId(p.getPostId(), member.getUserId())).forEach(p -> p.setHeart(true));

--- a/src/main/java/com/theocean/fundering/global/dto/PageResponse.java
+++ b/src/main/java/com/theocean/fundering/global/dto/PageResponse.java
@@ -16,7 +16,7 @@ public class PageResponse<T> {
     public PageResponse(final Slice<T> sliceContent) {
         content = sliceContent.getContent();
         currentPage = sliceContent.getNumber() + 1;
-        isLastPage = sliceContent.isLast();
+        isLastPage = !sliceContent.hasNext();
     }
 
     public static Slice<?> of(final List<?> content, final Pageable pageable, final boolean hasNext) {


### PR DESCRIPTION
## 주요 사항
- 문법에 맞지 않는 메소드 및 필드 이름 수정
- HeartRepository의 쿼리 일부 수정 (반환 값이 null일 시 0으로 반환)
- post 무한 스크롤 로직 수정을 위한 코드 변경(PageResponse, PostController, PostService, PostQuerydslRepository, PostQuerydslRepositoryImpl)

## 스크린샷


## 궁금한 점


### 관련 이슈

